### PR TITLE
Fix Korean step name for billing workflow

### DIFF
--- a/.github/workflows/billing.yml
+++ b/.github/workflows/billing.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 파일 채팅 + 생성 디렉터리
+      - name: 파일 체크아웃 및 디렉터리 생성
         uses: actions/checkout@v4
 
       - name: 파이썬 파일 echo 생성


### PR DESCRIPTION
## Summary
- fix typo in step name in billing workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68404070e01c83329cd75601fd8a528e