### PR TITLE
Fix workflow health monitor

### DIFF
--- a/.github/workflows/workflow-health-monitor.yml
+++ b/.github/workflows/workflow-health-monitor.yml
@@ -1,4 +1,5 @@
 name: Workflow Health Monitor and Alerting # 워크플로우의 이름
+description: Monitor recent workflow failures and notify via Slack
 
 on:
   workflow_run:
@@ -69,17 +70,13 @@ jobs:
         uses: mikefarah/yq@v4 # 'uses'는 'name'과 같은 수준 (4칸) 들여쓰기
 
       - name: Check for missing workflow descriptions # 'steps'의 다섯 번째 아이템
-        run: | # 'run'은 'name'과 같은 수준 (4칸) 들여쓰기
+        run: |
           MISSING_DESCRIPTIONS_COUNT=0
           MISSING_DESCRIPTIONS_LIST=""
           # .github/workflows 디렉토리 내의 모든 .yml 워크플로우 파일을 순회합니다.
           for workflow_file in .github/workflows/*.yml; do
-            # 파일이 존재하고 일반 파일인지 확인합니다.
             if [ -f "$workflow_file" ]; then
-              # 'yq'를 사용하여 'description' 필드를 읽습니다. 필드가 없으면 빈 문자열을 반환합니다.
               description=$(yq e '.description // ""' "$workflow_file")
-
-              # 'description'이 비어있는지 확인합니다.
               if [ -z "$description" ]; then
                 echo "::warning file=$workflow_file::Workflow '$workflow_file' is missing a 'description' field. Please add one for better documentation."
                 MISSING_DESCRIPTIONS_COUNT=$((MISSING_DESCRIPTIONS_COUNT + 1))
@@ -88,10 +85,9 @@ jobs:
             fi
           done
 
-          # 설명이 누락된 워크플로우가 하나라도 있다면 워크플로우를 실패시킵니다.
+          # 누락된 설명이 있어도 워크플로우를 실패시키지 않고 경고만 출력합니다.
           if [ "$MISSING_DESCRIPTIONS_COUNT" -gt 0 ]; then
-            echo "::error::Found $MISSING_DESCRIPTIONS_COUNT workflow(s) with missing 'description' field(s):$MISSING_DESCRIPTIONS_LIST"
-            exit 1 # 이 스텝이 실패하여 전체 워크플로우도 실패하게 됩니다.
+            echo "::warning::Found $MISSING_DESCRIPTIONS_COUNT workflow(s) with missing 'description' field(s):$MISSING_DESCRIPTIONS_LIST"
           else
             echo "✅ All workflow files have descriptions. Good for documentation!"
           fi


### PR DESCRIPTION
## Summary
- ensure workflow-health-monitor doesn't fail when descriptions are missing
- add a description to the monitor workflow

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68423c0b943083329388b212c041b08f