### PR TITLE
Add Rust install script and example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,3 +588,13 @@ bpbackup -f /path/to/output/corporate_banking_backup.zip -S <master_server> -L /
 ## 📅 보고서 생성 날짜
 2025년 06월 07일 06시 52분 55초 KST
 
+
+## 📦 Rust 프로그램 설치 및 예제 생성
+다음 스크립트를 실행하면 Rust를 설치하고 샘플 프로젝트를 생성할 수 있습니다.
+
+```bash
+./scripts/install_rust.sh
+cargo new rust-example
+```
+
+위 명령 실행 후 `rust-example/src/main.rs` 파일을 수정하여 원하는 Rust 코드를 작성할 수 있습니다.

--- a/rust-example/Cargo.toml
+++ b/rust-example/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rust-example"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/rust-example/src/main.rs
+++ b/rust-example/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/scripts/install_rust.sh
+++ b/scripts/install_rust.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Rust using rustup with default toolchain and no prompts
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Source cargo environment in current shell (if running interactively)
+if [ -f "$HOME/.cargo/env" ]; then
+  source "$HOME/.cargo/env"
+fi
+
+# Verify installation
+rustc --version
+cargo --version


### PR DESCRIPTION
## Summary
- add scripts/install_rust.sh for installing Rust
- document usage of the script in README
- create a simple `rust-example` with `cargo new`

## Testing
- `cargo build` in `rust-example`
- `cargo test` in `rust-example`


------
https://chatgpt.com/codex/tasks/task_e_6843e368c87c8332b0aa3b2721228b0e