### PR TITLE
Add blog generation workflow

### DIFF
--- a/.github/workflows/generate_blog.yml
+++ b/.github/workflows/generate_blog.yml
@@ -1,0 +1,29 @@
+name: Generate Repository Blog
+
+on:
+  schedule:
+    - cron: '0 0 */999 * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Generate blog
+        run: python scripts/generate_blog.py
+      - name: Commit blog
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add BLOG.md
+          git commit -m "chore: update generated blog" || echo "No changes"
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/BLOG.md
+++ b/BLOG.md
@@ -1,0 +1,74 @@
+# 코드 설명 블로그
+
+생성 시각: 2025-06-07 08:27:35
+
+GitHub Actions를 통해 자동 생성된 현재 코드 베이스 요약입니다.
+
+## 파일: `./README.md` (632 lines)
+
+```md
+# 🚀 davidkims/springboot 개발 저장소
+
+이 저장소는 Spring Boot 기반의 애플리케이션 개발 예제 및 관련 워크플로우를 포함합니다.
+아래 내용은 GitHub Actions 워크플로우에 의해 자동으로 생성 및 관리됩니다.
+
+```
+
+## 파일: `./rust-example/Cargo.toml` (6 lines)
+
+```toml
+[package]
+name = "rust-example"
+version = "0.1.0"
+edition = "2024"
+
+```
+
+## 파일: `./rust-example/src/main.rs` (3 lines)
+
+```rs
+fn main() {
+    println!("Hello, world!");
+}
+```
+
+## 파일: `./scripts/db_setup_and_backup.sh` (75 lines)
+
+```sh
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# ─── 환경 변수 (필요 시 오버라이드 가능) ───────────────────────────────────────
+: "${MYSQL_ROOT_PASSWORD:=rootpass123}"
+```
+
+## 파일: `./scripts/generate_blog.py` (45 lines)
+
+```py
+import os
+from datetime import datetime
+
+EXCLUDE_DIRS = {'.git', '.github'}
+EXTENSIONS = {'.py', '.sh', '.rs', '.yml', '.yaml', '.toml', '.md'}
+```
+
+## 파일: `./scripts/install_rust.sh` (14 lines)
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Rust using rustup with default toolchain and no prompts
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+```
+
+## 파일: `./scripts/optimize_disk.sh` (51 lines)
+
+```sh
+#!/bin/bash
+# optimize_disk.sh - Manage disk usage for given directories.
+# Usage: optimize_disk.sh DIR [DIR...]
+# Creates backups and removes old files if disk usage exceeds threshold.
+
+```
+

--- a/scripts/generate_blog.py
+++ b/scripts/generate_blog.py
@@ -1,0 +1,45 @@
+import os
+from datetime import datetime
+
+EXCLUDE_DIRS = {'.git', '.github'}
+EXTENSIONS = {'.py', '.sh', '.rs', '.yml', '.yaml', '.toml', '.md'}
+
+
+def collect_file_info(root_dir='.'):
+    file_info = []
+    for root, dirs, files in os.walk(root_dir):
+        dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+        for fname in files:
+            if fname.startswith('.'):
+                continue
+            path = os.path.join(root, fname)
+            if os.path.splitext(fname)[1] in EXTENSIONS:
+                try:
+                    with open(path, 'r', encoding='utf-8', errors='ignore') as fp:
+                        lines = fp.readlines()
+                except Exception:
+                    lines = []
+                snippet = ''.join(lines[:5])
+                file_info.append((path, len(lines), snippet))
+    return sorted(file_info)
+
+
+def generate_blog(file_info, output_path='BLOG.md'):
+    with open(output_path, 'w', encoding='utf-8') as out:
+        out.write('# 코드 설명 블로그\n\n')
+        out.write(f'생성 시각: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}\n\n')
+        out.write('GitHub Actions를 통해 자동 생성된 현재 코드 베이스 요약입니다.\n\n')
+        for path, length, snippet in file_info:
+            out.write(f'## 파일: `{path}` ({length} lines)\n\n')
+            ext = os.path.splitext(path)[1].lstrip('.')
+            out.write('```' + ext + '\n')
+            out.write(snippet)
+            if not snippet.endswith('\n'):
+                out.write('\n')
+            out.write('```\n\n')
+    print(f'Blog written to {output_path}')
+
+
+if __name__ == '__main__':
+    info = collect_file_info('.')
+    generate_blog(info)


### PR DESCRIPTION
## Summary
- add Python script to compile simple code blog
- schedule GitHub Actions workflow to run every 999 days
- generate initial `BLOG.md`

## Testing
- `cargo test --quiet --manifest-path rust-example/Cargo.toml`
- `bash -n scripts/db_setup_and_backup.sh`
- `bash -n scripts/install_rust.sh`
- `bash -n scripts/optimize_disk.sh`
- `python scripts/generate_blog.py`

------
https://chatgpt.com/codex/tasks/task_e_6843f793720c833287ae0b576549426d