### PR TITLE
Enforce HTTPS downloads in workflows

### DIFF
--- a/.github/workflows/auto-transactions.yml
+++ b/.github/workflows/auto-transactions.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: 🧰 Install Maven
         run: |
-          wget -q https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
+          wget --https-only --secure-protocol=TLSv1_2 -q https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
           tar xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz
           sudo mv apache-maven-${MAVEN_VERSION} ${MAVEN_HOME}
           echo "${MAVEN_HOME}/bin" >> $GITHUB_PATH

--- a/.github/workflows/delete_workflow_file.yml
+++ b/.github/workflows/delete_workflow_file.yml
@@ -30,7 +30,7 @@ jobs:
         REPO_OWNER="${{ github.repository_owner }}"
         REPO_NAME="${{ github.event.repository.name }}"
 
-        SHA=$(curl -s \
+        SHA=$(curl --proto '=https' --tlsv1.2 -s \
                    -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                    -H "Accept: application/vnd.github.v3+json" \
                    "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/contents/$FILE_PATH?ref=refs/heads/main" | jq -r '.sha')

--- a/.github/workflows/docker-ci-cd.yml
+++ b/.github/workflows/docker-ci-cd.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: ☁ Install OCI CLI
         run: |
-          curl -sL https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh | bash -s -- --accept-all-defaults --install-dir $HOME/oci-cli
+          curl --proto '=https' --tlsv1.2 -sL https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh | bash -s -- --accept-all-defaults --install-dir $HOME/oci-cli
           echo "$HOME/oci-cli/bin" >> $GITHUB_PATH
           echo "✅ OCI CLI 설치 완료: $(oci --version)"
 

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -39,7 +39,7 @@ jobs:
           echo "--- Docker 및 Docker Compose 수동 설치 시작 ---"
           sudo apt-get update -y
           sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          curl --proto '=https' --tlsv1.2 -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update -y
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/.github/workflows/download-security-regulationowasp.yml
+++ b/.github/workflows/download-security-regulationowasp.yml
@@ -55,7 +55,7 @@ jobs:
           echo "[Step] Downloading CVSS v3.1 Specification"
           URL="https://www.first.org/cvss/v3-1/specification-document"
           OUT="regulations/CVSS_v3.1_Spec_$(date +'%Y-%m-%d').pdf"
-          if curl -fSL "$URL" -o "$OUT"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT"; then
             echo "[Done] CVSS spec → $OUT"
           else
             echo "[Skip] CVSS spec not found"
@@ -67,7 +67,7 @@ jobs:
           echo "[Step] Downloading CVE Modified Feed"
           URL="https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz"
           OUT_GZ="regulations/CVE_Modified_$(date +'%Y-%m-%d').json.gz"
-          if curl -fSL "$URL" -o "$OUT_GZ"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT_GZ"; then
             echo "[Done] CVE feed → $OUT_GZ"
             gunzip -f "$OUT_GZ"
             echo "[Done] Uncompressed to regulations/CVE_Modified_$(date +'%Y-%m-%d').json"
@@ -81,7 +81,7 @@ jobs:
           echo "[Step] Downloading ISRM Guidelines (NIST SP800-30 Rev.1)"
           URL="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-30r1.pdf"
           OUT="regulations/NIST_SP800-30_Rev1_$(date +'%Y-%m-%d').pdf"
-          if curl -fSL "$URL" -o "$OUT"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT"; then
             echo "[Done] ISRM guidelines → $OUT"
           else
             echo "[Skip] ISRM guidelines not found"
@@ -93,7 +93,7 @@ jobs:
           echo "[Step] Downloading OWASP Top Ten 2013"
           URL="https://raw.githubusercontent.com/OWASP/Top10/master/2013/OWASP%20Top%2010%20-%202013.pdf"
           OUT="regulations/OWASP_Top_Ten_2013_$(date +'%Y-%m-%d').pdf"
-          if curl -fSL "$URL" -o "$OUT"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT"; then
             echo "[Done] OWASP 2013 → $OUT"
           else
             echo "[Skip] OWASP 2013 not available"
@@ -105,7 +105,7 @@ jobs:
           echo "[Step] Downloading OWASP Top Ten 2017"
           URL="https://raw.githubusercontent.com/OWASP/Top10/master/2017/OWASP%20Top%2010-2017%20%28en%29.pdf"
           OUT="regulations/OWASP_Top_Ten_2017_$(date +'%Y-%m-%d').pdf"
-          if curl -fSL "$URL" -o "$OUT"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT"; then
             echo "[Done] OWASP 2017 → $OUT"
           else
             echo "[Skip] OWASP 2017 not available"
@@ -117,7 +117,7 @@ jobs:
           echo "[Step] Downloading OWASP Top Ten 2021"
           URL="https://owasp.org/www-chapter-minneapolis-st-paul/download/20211216_OWASP-MSP_OWASP_Top_Ten_2021.pdf?raw=true"
           OUT="regulations/OWASP_Top_Ten_2021_$(date +'%Y-%m-%d').pdf"
-          if curl -fSL "$URL" -o "$OUT"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT"; then
             echo "[Done] OWASP 2021 → $OUT"
           else
             echo "[Skip] OWASP 2021 not available"

--- a/.github/workflows/download-security-regulations.yml
+++ b/.github/workflows/download-security-regulations.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           URL="https://www.first.org/cvss/v3-1/specification-document"
           OUT="regulations/CVSS_v3.1_Specification_$(date +'%Y-%m-%d').pdf"
-          if curl -fSL "$URL" -o "$OUT"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT"; then
             echo "✅ CVSS spec downloaded to $OUT"
           else
             echo "⚠️ CVSS spec not found at $URL, skipping."
@@ -40,7 +40,7 @@ jobs:
         run: |
           URL="https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz"
           OUT_GZ="regulations/CVE_Modified_$(date +'%Y-%m-%d').json.gz"
-          if curl -fSL "$URL" -o "$OUT_GZ"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT_GZ"; then
             echo "✅ CVE feed downloaded"
             gunzip -f "$OUT_GZ"
           else
@@ -52,7 +52,7 @@ jobs:
         run: |
           URL="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-30r1.pdf"
           OUT="regulations/NIST_SP800-30_Rev1_$(date +'%Y-%m-%d').pdf"
-          if curl -fSL "$URL" -o "$OUT"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT"; then
             echo "✅ ISRM guidelines downloaded to $OUT"
           else
             echo "⚠️ ISRM guidelines not found at $URL, skipping."

--- a/.github/workflows/encrypt-decrypt-tag-label.yml
+++ b/.github/workflows/encrypt-decrypt-tag-label.yml
@@ -39,7 +39,7 @@ jobs:
 
           echo "Codex 모델 사용량 추적 중..." >> $TAG_REPORT
 
-          curl https://api.openai.com/v1/usage \
+          curl --proto '=https' --tlsv1.2 https://api.openai.com/v1/usage \
             -H "Authorization: Bearer $OPENAI_API_KEY" \
             -H "Content-Type: application/json" \
             --silent > usage_raw.json || echo "❌ 사용량 불러오기 실패"

--- a/.github/workflows/generate-workflow-log06.yml
+++ b/.github/workflows/generate-workflow-log06.yml
@@ -49,17 +49,17 @@ jobs:
           echo "|---|---|---|---|---|---|---|---|" >> "$LOG_FILE"
 
           # 리포지토리 내 모든 워크플로우 ID 가져오기
-          WORKFLOWS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+          WORKFLOWS=$(curl --proto '=https' --tlsv1.2 -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/$REPO/actions/workflows" | jq -r '.workflows[] | .id')
 
           # 각 워크플로우에 대해 실행 로그 가져오기
           for WORKFLOW_ID in $WORKFLOWS; do
-            WORKFLOW_NAME=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            WORKFLOW_NAME=$(curl --proto '=https' --tlsv1.2 -s -H "Authorization: token $GITHUB_TOKEN" \
               "https://api.github.com/repos/$REPO/actions/workflows/$WORKFLOW_ID" | jq -r '.name')
 
             # 해당 워크플로우의 최근 100개 완료/진행/큐잉 상태의 실행 로그 가져오기
             # event 필터링을 통해 push, workflow_dispatch, schedule, pull_request 이벤트만 포함
-            RUNS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            RUNS=$(curl --proto '=https' --tlsv1.2 -s -H "Authorization: token $GITHUB_TOKEN" \
               "https://api.github.com/repos/$REPO/actions/workflows/$WORKFLOW_ID/runs?per_page=100&status=completed,in_progress,queued&event=push,workflow_dispatch,schedule,pull_request" \
               | jq -r '.workflow_runs[] | "\(.name) \(.id) \(.status) \(.conclusion) \(.created_at) \(.head_branch) \(.head_commit.committer.name) \(.head_commit.message | gsub("[\r\n]"; " "))"')
 

--- a/.github/workflows/mysql-upgrade.yml
+++ b/.github/workflows/mysql-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y apt-transport-https
-        wget https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb
+        wget --https-only --secure-protocol=TLSv1_2 https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure mysql-apt-config
         sudo apt-get update

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           URL="https://www.first.org/cvss/v3-1/specification-document"
           OUT="regulations/CVSS_v3.1_Specification_$(date +'%Y-%m-%d').pdf"
-          if curl -fSL "$URL" -o "$OUT"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT"; then
             echo "✅ CVSS spec downloaded to $OUT"
           else
             echo "⚠️ CVSS spec not found at $URL, skipping."
@@ -40,7 +40,7 @@ jobs:
         run: |
           URL="https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz"
           OUT_GZ="regulations/CVE_Modified_$(date +'%Y-%m-%d').json.gz"
-          if curl -fSL "$URL" -o "$OUT_GZ"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT_GZ"; then
             echo "✅ CVE feed downloaded"
             gunzip -f "$OUT_GZ"
           else
@@ -52,7 +52,7 @@ jobs:
         run: |
           URL="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-30r1.pdf"
           OUT="regulations/NIST_SP800-30_Rev1_$(date +'%Y-%m-%d').pdf"
-          if curl -fSL "$URL" -o "$OUT"; then
+          if curl --proto '=https' --tlsv1.2 -fSL "$URL" -o "$OUT"; then
             echo "✅ ISRM guidelines downloaded to $OUT"
           else
             echo "⚠️ ISRM guidelines not found at $URL, skipping."

--- a/.github/workflows/swift-backup.yml
+++ b/.github/workflows/swift-backup.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang libicu-dev libpython3-dev zip
-          curl -fsSL https://download.swift.org/swift-5.9-release/ubuntu2204/swift-5.9-RELEASE/swift-5.9-RELEASE-ubuntu22.04.tar.gz -o swift.tar.gz
+          curl --proto '=https' --tlsv1.2 -fsSL https://download.swift.org/swift-5.9-release/ubuntu2204/swift-5.9-RELEASE/swift-5.9-RELEASE-ubuntu22.04.tar.gz -o swift.tar.gz
           sudo mkdir -p /opt/swift
           sudo tar -xzf swift.tar.gz -C /opt/swift --strip-components=1
           echo "/opt/swift/usr/bin" >> $GITHUB_PATH
@@ -51,7 +51,7 @@ jobs:
 
       - name: ☁️ Oracle OCI CLI 설치
         run: |
-          curl -sL https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh | bash -s -- --accept-all-defaults
+          curl --proto '=https' --tlsv1.2 -sL https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh | bash -s -- --accept-all-defaults
           echo "$HOME/bin" >> $GITHUB_PATH
           oci --version || echo "✅ OCI CLI 설치됨"
 


### PR DESCRIPTION
## Summary
- update `curl` commands to restrict protocol to HTTPS and require TLS v1.2
- enforce HTTPS in `wget` downloads

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68444cfbd4148332a590055eede28dfc