### PR TITLE
Add Docker setup automation

### DIFF
--- a/.github/workflows/docker-setup.yml
+++ b/.github/workflows/docker-setup.yml
@@ -1,0 +1,28 @@
+name: Hourly Docker Setup
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  setup-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Docker environment setup
+        run: bash scripts/setup_docker_environment.sh
+      - name: Commit setup log
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docker_setup.log
+          if git diff-index --quiet HEAD --; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update docker setup log"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+docker_data/
+rust-example/target/

--- a/docker_setup.log
+++ b/docker_setup.log
@@ -1,0 +1,5 @@
+2025-06-08 00:06:53 - Starting setup
+Docker already installed
+Creating disk file docker_data/disk.img
+Pulling Docker image nginx:latest
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?

--- a/scripts/setup_docker_environment.sh
+++ b/scripts/setup_docker_environment.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default variables (can be overridden)
+: "${IMAGE:=nginx:latest}"
+: "${CONTAINER_NAME:=my-nginx}"
+: "${DATA_DIR:=docker_data}"
+: "${DISK_FILE:=docker_data/disk.img}"
+: "${LOG_FILE:=docker_setup.log}"
+
+install_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Installing Docker..."
+    sudo apt-get update
+    sudo apt-get install -y docker.io
+    if command -v systemctl >/dev/null 2>&1; then
+      sudo systemctl enable --now docker || true
+    else
+      sudo service docker start || true
+    fi
+  else
+    echo "Docker already installed"
+  fi
+}
+
+setup_disk() {
+  mkdir -p "$DATA_DIR"
+  if [ ! -f "$DISK_FILE" ]; then
+    echo "Creating disk file $DISK_FILE"
+    sudo fallocate -l 50M "$DISK_FILE" || sudo dd if=/dev/zero of="$DISK_FILE" bs=1M count=50
+  fi
+  sudo chmod 600 "$DISK_FILE"
+}
+
+pull_image() {
+  echo "Pulling Docker image $IMAGE"
+  sudo docker pull "$IMAGE"
+}
+
+run_container() {
+  if ! sudo docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    if sudo docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+      sudo docker rm "$CONTAINER_NAME"
+    fi
+    echo "Starting container $CONTAINER_NAME"
+    sudo docker run -d --name "$CONTAINER_NAME" -v "$PWD/$DATA_DIR":/usr/share/nginx/html:ro "$IMAGE"
+  else
+    echo "Container $CONTAINER_NAME already running"
+  fi
+}
+
+main() {
+  {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Starting setup"
+    install_docker
+    setup_disk
+    pull_image
+    run_container
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Setup complete"
+  } >> "$LOG_FILE" 2>&1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `setup_docker_environment.sh` script to manage Docker installation and container
- create `docker-setup.yml` workflow to run the script every hour
- ignore temporary directories
- include initial `docker_setup.log`

## Testing
- `cargo test --quiet` in `rust-example`
- `bash scripts/setup_docker_environment.sh` *(fails: System has not been booted with systemd)*

------
https://chatgpt.com/codex/tasks/task_e_6844d3996684833291e008ebe45aa329