### PR TITLE
Add workflow maintenance automation

### DIFF
--- a/.github/workflows/workflow-maintenance.yml
+++ b/.github/workflows/workflow-maintenance.yml
@@ -1,0 +1,26 @@
+name: Workflow Maintenance
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+    - cron: '*/5 * * * 0'
+  workflow_dispatch:
+
+jobs:
+  maintain:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install requests
+      - name: Run maintenance
+        run: python scripts/workflow_maintenance.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}

--- a/scripts/workflow_maintenance.py
+++ b/scripts/workflow_maintenance.py
@@ -1,0 +1,71 @@
+import os
+import requests
+import datetime
+from pathlib import Path
+
+GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
+REPO_OWNER = os.environ.get('REPO_OWNER')
+REPO_NAME = os.environ.get('REPO_NAME')
+
+API_URL = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}"
+HEADERS = {
+    "Authorization": f"token {GITHUB_TOKEN}",
+    "Accept": "application/vnd.github.v3+json"
+}
+
+
+def create_tag_and_label():
+    tag_name = datetime.datetime.utcnow().strftime("auto-%Y%m%d%H%M%S")
+
+    # Create git tag pointing at main
+    ref_resp = requests.get(f"{API_URL}/git/ref/heads/main", headers=HEADERS)
+    if ref_resp.ok:
+        sha = ref_resp.json().get("object", {}).get("sha")
+        requests.post(
+            f"{API_URL}/git/refs",
+            headers=HEADERS,
+            json={"ref": f"refs/tags/{tag_name}", "sha": sha}
+        )
+
+    # Create issue label with same name if it does not exist
+    requests.post(
+        f"{API_URL}/labels",
+        headers=HEADERS,
+        json={"name": tag_name, "color": "0e8a16"}
+    )
+
+    return tag_name
+
+
+def disable_and_delete_failed_runs():
+    runs_resp = requests.get(f"{API_URL}/actions/runs?per_page=100", headers=HEADERS)
+    if not runs_resp.ok:
+        print("Unable to fetch workflow runs")
+        return
+
+    for run in runs_resp.json().get("workflow_runs", []):
+        if run.get("conclusion") == "failure":
+            workflow_id = run.get("workflow_id")
+            run_id = run.get("id")
+            # disable the workflow
+            requests.put(
+                f"{API_URL}/actions/workflows/{workflow_id}/disable",
+                headers=HEADERS
+            )
+            # delete the failed run
+            requests.delete(
+                f"{API_URL}/actions/runs/{run_id}",
+                headers=HEADERS
+            )
+
+
+def main():
+    if not GITHUB_TOKEN:
+        print("GITHUB_TOKEN not provided")
+        return
+    create_tag_and_label()
+    disable_and_delete_failed_runs()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- automate maintenance for GitHub workflows
- disable failed workflows and delete failed runs
- generate tag and label for tracking

## Testing
- `python -m py_compile scripts/workflow_maintenance.py`

------
https://chatgpt.com/codex/tasks/task_e_6844ead88c2c8332a1022f0a8ce7c69e