### PR TITLE
Add Docker setup and backup scripts

### DIFF
--- a/finance_app/Dockerfile
+++ b/finance_app/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y curl
+
+COPY start.sh /app/start.sh
+
+CMD ["bash", "/app/start.sh"]

--- a/finance_app/start.sh
+++ b/finance_app/start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Finance app started"
+# Placeholder for the actual application logic
+exec tail -f /dev/null

--- a/scripts/docker_backup.sh
+++ b/scripts/docker_backup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKUP_DIR="/var/backups/docker_finance"
+DATE=$(date +'%Y%m%d%H')
+
+mkdir -p "$BACKUP_DIR"
+
+sudo docker save finance_app:v1 > "$BACKUP_DIR/finance_app_v1_${DATE}.tar"
+
+if sudo docker ps -a --format '{{.Names}}' | grep -q '^finance_container$'; then
+  sudo docker container commit finance_container finance_container_backup:v1
+  sudo docker save finance_container_backup:v1 > "$BACKUP_DIR/finance_container_backup_v1_${DATE}.tar"
+  sudo docker rmi finance_container_backup:v1
+fi

--- a/scripts/setup_finance_docker.sh
+++ b/scripts/setup_finance_docker.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="finance_app:v1"
+CONTAINER_NAME="finance_container"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKUP_SCRIPT="${SCRIPT_DIR}/docker_backup.sh"
+CRON_FILE="/etc/cron.d/finance_backup"
+
+install_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Installing Docker..."
+    sudo apt-get update
+    sudo apt-get install -y docker.io
+    sudo systemctl enable --now docker || sudo service docker start
+  else
+    echo "Docker already installed"
+  fi
+}
+
+build_image() {
+  echo "Building Docker image ${IMAGE_NAME}"
+  sudo docker build -t "$IMAGE_NAME" "${SCRIPT_DIR}/../finance_app"
+}
+
+run_container() {
+  if sudo docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "Container ${CONTAINER_NAME} already running"
+  else
+    if sudo docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+      sudo docker rm "$CONTAINER_NAME"
+    fi
+    echo "Starting container ${CONTAINER_NAME}"
+    sudo docker run -d --name "$CONTAINER_NAME" "$IMAGE_NAME"
+  fi
+}
+
+setup_cron() {
+  sudo mkdir -p /var/backups/docker_finance
+  local cron_entry="0 * * * * root ${BACKUP_SCRIPT}"
+  echo "$cron_entry" | sudo tee "$CRON_FILE" >/dev/null
+  sudo chmod 644 "$CRON_FILE"
+  sudo systemctl reload cron || sudo service cron reload
+}
+
+main() {
+  install_docker
+  build_image
+  run_container
+  setup_cron
+  echo "Setup completed. Backups will run hourly."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- provide minimal finance example Dockerfile and start script
- add backup script for Docker image and container
- add setup script to build and run the container with a cron job for backups

## Testing
- `bash -n scripts/docker_backup.sh`
- `bash -n scripts/setup_finance_docker.sh`
- `shellcheck scripts/docker_backup.sh` *(fails: command not found)*
- `shellcheck scripts/setup_finance_docker.sh` *(fails: command not found)*
- attempted `bash scripts/setup_finance_docker.sh` *(fails due to systemd)*

------
https://chatgpt.com/codex/tasks/task_e_6846d7f7d8d48332a0420e657ba3b90c