### PR TITLE
Add finance workflow scripts

### DIFF
--- a/scripts/full_setup.sh
+++ b/scripts/full_setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Install Docker and build/run finance_app container
+"${SCRIPT_DIR}/setup_finance_docker.sh"
+
+# Install MySQL/PostgreSQL and create databases
+"${SCRIPT_DIR}/db_setup_and_backup.sh"
+
+# Generate bulk transactions for Shinhan Bank sample
+"${SCRIPT_DIR}/generate_shinhan_transactions.sh"
+
+echo "Finance workflow completed."

--- a/scripts/generate_shinhan_transactions.sh
+++ b/scripts/generate_shinhan_transactions.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Number of transactions to generate (default 1000)
+: "${NUM_TRANSACTIONS:=1000}"
+: "${MYSQL_USER:=finance_user}"
+: "${MYSQL_PASS:=finance_pass}"
+: "${MYSQL_DB:=finance_db}"
+
+cat <<SQL | mysql -u "$MYSQL_USER" -p"$MYSQL_PASS" "$MYSQL_DB"
+CREATE TABLE IF NOT EXISTS shinhan_transactions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    customer_name VARCHAR(100),
+    account_number VARCHAR(20),
+    amount DECIMAL(12,2),
+    currency VARCHAR(10),
+    transaction_date DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+SQL
+
+echo "Inserting $NUM_TRANSACTIONS transactions into $MYSQL_DB.shinhan_transactions"
+for i in $(seq 1 "$NUM_TRANSACTIONS"); do
+  NAME="Customer_$i"
+  ACC_NUM=$(printf '110-%06d-%06d' $((RANDOM%1000000)) $((RANDOM%1000000)))
+  AMOUNT=$(( RANDOM % 1000000 + 100 ))
+  CURRENCY="KRW"
+  cat <<SQL | mysql -u "$MYSQL_USER" -p"$MYSQL_PASS" "$MYSQL_DB"
+INSERT INTO shinhan_transactions (customer_name, account_number, amount, currency)
+VALUES ('$NAME', '$ACC_NUM', $AMOUNT, '$CURRENCY');
+SQL
+  # small delay to avoid overwhelming MySQL
+  sleep 0.01
+done
+
+echo "Done." 


### PR DESCRIPTION
## Summary
- add script to generate bulk Shinhan Bank transactions
- add full workflow shell script to set up Docker and databases

## Testing
- `shellcheck scripts/full_setup.sh`
- `shellcheck scripts/generate_shinhan_transactions.sh`
- `cargo fmt -- --check` *(failed: rustfmt component missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848330c8cf08332994bcf663e05e426