### PR TITLE
Add token generation logic to workflows

### DIFF
--- a/.github/workflows/encrypt-decrypt-tag-label.yml
+++ b/.github/workflows/encrypt-decrypt-tag-label.yml
@@ -20,7 +20,19 @@ jobs:
       - name: 📁 저장소 체크아웃
         uses: actions/checkout@v4
 
+      - name: 🔑 Generate OpenAI token
+        id: generate_token
+        run: bash scripts/generate_openai_token.sh
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        continue-on-error: true
+
+      - name: Skip when token missing
+        if: steps.generate_token.outcome != 'success'
+        run: echo "Token unavailable; skipping workflow." && exit 0
+
       - name: 🔐 암호화 / 복호화 태그 파일 생성
+        if: steps.generate_token.outcome == 'success'
         run: |
           mkdir -p $ENCRYPT_DIR $DECRYPT_DIR
           for company in 삼성 현대 롯데; do
@@ -33,6 +45,7 @@ jobs:
           done
 
       - name: 💰 Codex 요금 API 호출 및 보고서 생성
+        if: steps.generate_token.outcome == 'success'
         run: |
           echo "# 💵 Codex 요금 추적 보고서" > $TAG_REPORT
           echo "실행 시간: $(date)" >> $TAG_REPORT
@@ -55,6 +68,7 @@ jobs:
           cat $TAG_REPORT
 
       - name: 🧾 태그 및 보고서 아카이브
+        if: steps.generate_token.outcome == 'success'
         run: |
           mkdir -p output
           zip -j output/encrypted_files.zip $ENCRYPT_DIR/*.enc $DECRYPT_DIR/*.dec

--- a/.github/workflows/tokencheck.yml
+++ b/.github/workflows/tokencheck.yml
@@ -16,6 +16,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: 🔑 Generate OpenAI token
+        id: generate_token
+        run: bash scripts/generate_openai_token.sh
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        continue-on-error: true
+
+      - name: Skip job when token missing
+        if: steps.generate_token.outcome != 'success'
+        run: echo "Token unavailable; skipping workflow." && exit 0
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -56,9 +67,11 @@ jobs:
           echo "    print(f'::error::Error calling OpenAI API: {e}')" >> scripts/openai_usage.py
 
       - name: Run OpenAI API Usage Script
+        if: steps.generate_token.outcome == 'success'
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
         run: python scripts/openai_usage.py
 
       - name: ✅ Final Log
+        if: steps.generate_token.outcome == 'success'
         run: echo "✅ OpenAI API 사용량 로그 출력 완료. Actions 로그에서 확인하세요."

--- a/scripts/generate_openai_token.sh
+++ b/scripts/generate_openai_token.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Script to load or create an OpenAI API token.
+# Usage: generate_openai_token.sh [token_file]
+set -e
+
+TOKEN_FILE="$1"
+
+# If OPENAI_API_KEY is already provided, use it
+if [ -n "$OPENAI_API_KEY" ]; then
+  TOKEN="$OPENAI_API_KEY"
+elif [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ]; then
+  TOKEN="$(cat "$TOKEN_FILE")"
+else
+  if command -v openai >/dev/null 2>&1; then
+    # Attempt to create a token via openai CLI (placeholder)
+    TOKEN="$(openai api keys.create 2>/dev/null | tail -n 1 || true)"
+  fi
+fi
+
+if [ -z "$TOKEN" ]; then
+  echo "Failed to obtain OPENAI_API_KEY" >&2
+  exit 1
+fi
+
+# Mask the token in logs and export
+echo "::add-mask::$TOKEN"
+echo "OPENAI_API_KEY=$TOKEN" >> "$GITHUB_ENV"
+
+# Output token for step condition checks
+echo "token=$TOKEN" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- create `generate_openai_token.sh` for generating or loading an OpenAI token
- add token generation and skip logic to `tokencheck.yml`
- add the same token generation logic to `encrypt-decrypt-tag-label.yml`

## Testing
- `cargo fmt -- --check` *(failed: component not installed)*
- `shellcheck scripts/generate_openai_token.sh` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498616d1ac8332847351be62cab79d