### PR TITLE
Add Java and Maven setup script

### DIFF
--- a/.github/workflows/install-java-maven.yml
+++ b/.github/workflows/install-java-maven.yml
@@ -1,0 +1,19 @@
+name: Setup Java and Maven
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'setup-*'
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run setup script
+        run: |
+          chmod +x scripts/install_java_maven.sh
+          ./scripts/install_java_maven.sh

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ This README was last updated by a GitHub Actions workflow.
 Current Python version: Python 3.13.3
 Number of Python files: 2
 Number of Java files: 0
+
+### Java and Maven Setup
+Run `scripts/install_java_maven.sh` to install the latest JDK and Maven, backup existing installations, and optionally build a Spring Boot project placed under `/opt/springboot`.
+

--- a/scripts/install_java_maven.sh
+++ b/scripts/install_java_maven.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Directories
+JAVA_DIR="/opt/java"
+MAVEN_DIR="/opt/maven"
+SPRING_DIR="/opt/springboot"
+BACKUP_ROOT="/opt/backups"
+DATE_TAG="$(date +%Y%m%d%H%M%S)"
+
+# Create directories
+sudo mkdir -p "$JAVA_DIR" "$MAVEN_DIR" "$SPRING_DIR" "$BACKUP_ROOT"
+
+# Backup existing installations
+for dir in "$JAVA_DIR" "$MAVEN_DIR" "$SPRING_DIR"; do
+  if [ -d "$dir" ] && [ "$(ls -A "$dir")" ]; then
+    backup="$BACKUP_ROOT/$(basename "$dir")-$DATE_TAG.tar.gz"
+    sudo tar -czf "$backup" -C "$dir" .
+    echo "Backed up $dir to $backup"
+  fi
+  sudo rm -rf "$dir"/*
+done
+
+# Install latest Java (Temurin)
+sudo apt-get update
+sudo apt-get install -y wget tar
+JDK_URL="https://api.adoptium.net/v3/binary/latest/temurin?package=jdk&architecture=x64&heap_size=normal&image_type=jdk&os=linux&arch=x64"
+wget -O /tmp/jdk.tar.gz "$JDK_URL"
+sudo tar -xzf /tmp/jdk.tar.gz -C "$JAVA_DIR" --strip-components=1
+
+# Install latest Maven
+MAVEN_VERSION=$(curl -s https://api.github.com/repos/apache/maven/releases/latest | grep tag_name | cut -d '"' -f4)
+MAVEN_URL="https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION#v}/binaries/apache-maven-${MAVEN_VERSION#v}-bin.tar.gz"
+wget -O /tmp/maven.tar.gz "$MAVEN_URL"
+sudo tar -xzf /tmp/maven.tar.gz -C "$MAVEN_DIR" --strip-components=1
+
+# Set permissions
+sudo chmod -R 755 "$JAVA_DIR" "$MAVEN_DIR" "$SPRING_DIR"
+
+# If springboot project exists, build and backup jar
+if [ -f "$SPRING_DIR/pom.xml" ]; then
+  "$MAVEN_DIR/bin/mvn" -f "$SPRING_DIR/pom.xml" clean package
+  jar_file=$(find "$SPRING_DIR/target" -name '*.jar' | head -n 1)
+  if [ -f "$jar_file" ]; then
+    sudo cp "$jar_file" "$BACKUP_ROOT/springboot-$DATE_TAG.jar"
+    echo "Spring Boot jar backed up to $BACKUP_ROOT/springboot-$DATE_TAG.jar"
+  fi
+fi
+
+echo "Java and Maven installation complete."


### PR DESCRIPTION
## Summary
- document how to install Java and Maven
- add script `install_java_maven.sh` to install and back up Java, Maven and Spring Boot app
- add workflow `install-java-maven.yml` that runs the script

## Testing
- `shellcheck scripts/install_java_maven.sh`
- `cargo fmt -- --check` *(failed: 'cargo-fmt' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c17926a6c8332b70264074b7f7049