### PR TITLE
Add workflow to auto-delete failed runs

### DIFF
--- a/.github/workflows/delete-failed-workflow-runs.yml
+++ b/.github/workflows/delete-failed-workflow-runs.yml
@@ -1,0 +1,44 @@
+name: Delete Failed Workflow Runs
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete failed workflow runs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const perPage = 50;
+            let page = 1;
+            while (true) {
+              const runs = await github.rest.actions.listWorkflowRunsForRepo({
+                owner,
+                repo,
+                status: 'completed',
+                per_page: perPage,
+                page,
+              });
+              if (runs.data.workflow_runs.length === 0) {
+                break;
+              }
+              for (const run of runs.data.workflow_runs) {
+                if (run.conclusion === 'failure') {
+                  await github.rest.actions.deleteWorkflowRun({
+                    owner,
+                    repo,
+                    run_id: run.id,
+                  });
+                  console.log(`Deleted failed run ${run.id}`);
+                }
+              }
+              page += 1;
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow_docs/delete-failed-workflow-runs.md
+++ b/workflow_docs/delete-failed-workflow-runs.md
@@ -1,0 +1,8 @@
+# Delete Failed Workflow Runs
+
+Source: `.github/workflows/delete-failed-workflow-runs.yml`
+
+**Triggers**: workflow_dispatch, schedule
+
+## Steps
+- Delete failed workflow runs using the GitHub API


### PR DESCRIPTION
## Summary
- add workflow to delete failed runs nightly
- document new workflow

## Testing
- `cargo fmt -- --check` *(failed: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68594cdac2088332b5cd876c20712f65