### PR TITLE
Add MySQL setup and migration utility

### DIFF
--- a/migrations/init.sql
+++ b/migrations/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS sample_table (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50)
+);
+INSERT INTO sample_table(name) VALUES ('Alice'), ('Bob'), ('Charlie');

--- a/scripts/mysql_install_and_migrate.sh
+++ b/scripts/mysql_install_and_migrate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default configuration
+: "${MYSQL_ROOT_PASSWORD:=rootpass123}"
+: "${MYSQL_DB:=example_db}"
+: "${MYSQL_USER:=example_user}"
+: "${MYSQL_PASS:=example_pass}"
+: "${MIGRATION_FILE:=migrations/init.sql}"
+
+install_mysql() {
+  if ! command -v mysql >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server
+  fi
+}
+
+secure_mysql() {
+  sudo systemctl stop mysql
+  sudo mysqld_safe --skip-networking --skip-grant-tables &
+  sleep 10
+  echo "FLUSH PRIVILEGES; ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '${MYSQL_ROOT_PASSWORD}'; FLUSH PRIVILEGES;" | sudo mysql -u root
+  sudo killall mysqld
+  sleep 5
+  sudo systemctl start mysql
+}
+
+create_db_and_user() {
+  mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "CREATE DATABASE IF NOT EXISTS ${MYSQL_DB};"
+  mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PASS}';"
+  mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "GRANT ALL PRIVILEGES ON ${MYSQL_DB}.* TO '${MYSQL_USER}'@'localhost';"
+  mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "FLUSH PRIVILEGES;"
+}
+
+run_migration() {
+  if [ -f "${MIGRATION_FILE}" ]; then
+    mysql -u "${MYSQL_USER}" -p"${MYSQL_PASS}" "${MYSQL_DB}" < "${MIGRATION_FILE}"
+  else
+    echo "Migration file ${MIGRATION_FILE} not found" >&2
+    exit 1
+  fi
+}
+
+show_count() {
+  mysql -u "${MYSQL_USER}" -p"${MYSQL_PASS}" -N -e "USE ${MYSQL_DB}; SELECT COUNT(*) FROM sample_table;"
+}
+
+main() {
+  install_mysql
+  secure_mysql
+  create_db_and_user
+  run_migration
+  echo "Row count in sample_table:"
+  show_count
+}
+
+main "$@"

--- a/setup_guides/mysql/README.md
+++ b/setup_guides/mysql/README.md
@@ -1,0 +1,16 @@
+# MySQL Setup and Migration Guide
+
+This guide explains how to install MySQL, run a simple migration, and check the number of rows inserted.
+
+## Install MySQL on Ubuntu
+```bash
+sudo apt update
+sudo DEBIAN_FRONTEND=noninteractive apt install -y mysql-server
+```
+
+## Run the migration script
+Inside the repository root:
+```bash
+./scripts/mysql_install_and_migrate.sh
+```
+This script installs MySQL if needed, creates a database and user, runs `migrations/init.sql`, and prints the row count from `sample_table`.


### PR DESCRIPTION
## Summary
- add script to install MySQL, run a migration and print a row count
- document MySQL setup in a new guide
- include sample migration SQL

## Testing
- `shellcheck scripts/mysql_install_and_migrate.sh`
- `cargo fmt --manifest-path rust-example/Cargo.toml -- --check` *(fails: 'cargo-fmt' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bfc1aad208332b4829bb90f760b24