### PR TITLE
Fix shard generation call in massive disk workflow

### DIFF
--- a/.github/workflows/backup-and-api-check.yml
+++ b/.github/workflows/backup-and-api-check.yml
@@ -256,7 +256,7 @@ jobs:
           export BASE_DIRS BASE_FILES BASE_KB BASE_PREFIX MULT MNT
 
           seq 1 "$SHARDS" \
-            | xargs -I{} -P "$PJ" bash -lc 'ionice -c'"$IO_CLASS"' -n'"$IO_PRIO"' nice -n '"$CPU_NICE"' gen_one_shard "$@"' _ {}
+            | xargs -I{} -P "$PJ" bash -c 'ionice -c"$IO_CLASS" -n"$IO_PRIO" nice -n "$CPU_NICE" gen_one_shard "$1"' _ {}
 
       - name: 📊 Size reports
         shell: bash


### PR DESCRIPTION
## Summary
- ensure `gen_one_shard` function is available by invoking shard generation via `bash -c`

## Testing
- `bash scripts/check_workflows.sh` *(fails: line-length errors across workflows)*
- `yamllint .github/workflows/backup-and-api-check.yml` *(fails: many line-length errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ca4ee0c7883328beb5d508021ce22