### PR TITLE
feat: scan multiple services with defender bot

### DIFF
--- a/.github/workflows/defender-bot.yml
+++ b/.github/workflows/defender-bot.yml
@@ -1,8 +1,9 @@
+---
 name: 🛡️ Defender Bot
 
-on:
+"on":
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
   schedule:
     - cron: '0 0 * * 0'
@@ -15,9 +16,16 @@ permissions:
 jobs:
   security-scan:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: ['.', 'src', 'scripts', 'rust-example', 'finance_app']
+    name: Scan ${{ matrix.service }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          sparse-checkout: ${{ matrix.service }}
+          sparse-checkout-cone-mode: false
 
       - name: Run Microsoft Security DevOps
         uses: microsoft/security-devops-action@latest
@@ -27,3 +35,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: msdo.sarif
+          category: defender-bot-${{ matrix.service }}


### PR DESCRIPTION
## Summary
- add matrix strategy so Defender Bot scans each service directory
- upload SARIF results with service-specific categories

## Testing
- `yamllint .github/workflows/defender-bot.yml`

------
https://chatgpt.com/codex/tasks/task_e_689ca8d7cf408332ac58ba995c4bc9d6