### PR TITLE
chore: expand dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,19 @@ updates:
     labels:
       - "automerge"
       - "dependencies"
+  - package-ecosystem: "cargo"
+    directory: "/rust-example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "🔄 cargo"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "docker"
+    directory: "/finance_app"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "🔄 docker"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
- include Cargo and Docker directories in Dependabot config

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689caa0fd7088332bca989f0d2996364