### PR TITLE
Add Defender Bot EchoOps workflow

### DIFF
--- a/.github/workflows/defender-bot-workflow.yml
+++ b/.github/workflows/defender-bot-workflow.yml
@@ -1,0 +1,19 @@
+name: "⚔️ Defender Bot EchoOps"
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  echo-ops:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Run Defender Bot workflow
+        run: bash scripts/defender_bot_workflow.sh

--- a/echo/db/database.sql
+++ b/echo/db/database.sql
@@ -1,0 +1,2 @@
+-- Placeholder SQL managed by Defender Bot.
+-- Define schema and migrations here.

--- a/echo/firewall/rules.conf
+++ b/echo/firewall/rules.conf
@@ -1,0 +1,2 @@
+# Placeholder firewall rules managed by Defender Bot.
+# Specify allowed and blocked ports/IPs.

--- a/echo/perm/permissions.conf
+++ b/echo/perm/permissions.conf
@@ -1,0 +1,2 @@
+# Placeholder permissions configuration managed by Defender Bot.
+# Update with system-specific user and group rules.

--- a/echo/services/upgrade.sh
+++ b/echo/services/upgrade.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Placeholder service upgrade script managed by Defender Bot.
+# Add service-specific upgrade commands below.

--- a/scripts/defender_bot_workflow.sh
+++ b/scripts/defender_bot_workflow.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Automated setup for Defender Bot echo directories and files.
+# Creates and maintains placeholders for permissions, database, firewall, and service upgrades.
+set -euo pipefail
+
+BASE_DIR="$(git rev-parse --show-toplevel)/echo"
+
+# Create required directories
+mkdir -p "$BASE_DIR/perm" "$BASE_DIR/db" "$BASE_DIR/firewall" "$BASE_DIR/services"
+
+# Permissions file
+if [ ! -f "$BASE_DIR/perm/permissions.conf" ]; then
+  cat <<'PERM' > "$BASE_DIR/perm/permissions.conf"
+# Placeholder permissions configuration managed by Defender Bot.
+# Update with system-specific user and group rules.
+PERM
+fi
+
+# Database SQL file
+if [ ! -f "$BASE_DIR/db/database.sql" ]; then
+  cat <<'SQL' > "$BASE_DIR/db/database.sql"
+-- Placeholder SQL managed by Defender Bot.
+-- Define schema and migrations here.
+SQL
+fi
+
+# Firewall rules file
+if [ ! -f "$BASE_DIR/firewall/rules.conf" ]; then
+  cat <<'FIRE' > "$BASE_DIR/firewall/rules.conf"
+# Placeholder firewall rules managed by Defender Bot.
+# Specify allowed and blocked ports/IPs.
+FIRE
+fi
+
+# Service upgrade script
+if [ ! -f "$BASE_DIR/services/upgrade.sh" ]; then
+  cat <<'UPGRADE' > "$BASE_DIR/services/upgrade.sh"
+#!/usr/bin/env bash
+# Placeholder service upgrade script managed by Defender Bot.
+# Add service-specific upgrade commands below.
+UPGRADE
+  chmod +x "$BASE_DIR/services/upgrade.sh"
+fi
+
+# Set secure permissions
+chmod 600 "$BASE_DIR/perm/permissions.conf" "$BASE_DIR/db/database.sql" "$BASE_DIR/firewall/rules.conf"
+chmod 700 "$BASE_DIR/services/upgrade.sh"
+
+echo "[Defender Bot] Echo directories and files verified at $(date -u)"


### PR DESCRIPTION
## Summary
- add Defender Bot script that ensures echo directories and placeholder configs
- schedule hourly workflow to run Defender Bot
- scaffold initial echo permissions, DB, firewall, and service upgrade files

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689caaec36ec833290bb7163a0126911