### PR TITLE
Add Defender Bot EchoOps workflow

### DIFF
--- a/.github/workflows/defender-bot-workflow.yml
+++ b/.github/workflows/defender-bot-workflow.yml
@@ -1,0 +1,33 @@
+name: "🛡️ Defender Bot"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Run Microsoft Security DevOps
+        uses: microsoft/security-devops-action@latest
+        id: msdo
+
+      - name: Upload results to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: msdo.sarif
+
+      - name: Run Defender Bot maintenance
+        run: bash scripts/defender_bot_workflow.sh

--- a/echo/db/database.sql
+++ b/echo/db/database.sql
@@ -1,0 +1,2 @@
+-- Placeholder SQL managed by Defender Bot.
+-- Define schema and migrations here.

--- a/echo/firewall/rules.conf
+++ b/echo/firewall/rules.conf
@@ -1,0 +1,2 @@
+# Placeholder firewall rules managed by Defender Bot.
+# Specify allowed and blocked ports/IPs.

--- a/echo/perm/permissions.conf
+++ b/echo/perm/permissions.conf
@@ -1,0 +1,2 @@
+# Placeholder permissions configuration managed by Defender Bot.
+# Update with system-specific user and group rules.

--- a/echo/services/upgrade.sh
+++ b/echo/services/upgrade.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Placeholder service upgrade script managed by Defender Bot.
+# Add service-specific upgrade commands below.

--- a/scripts/defender_bot_workflow.sh
+++ b/scripts/defender_bot_workflow.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Automated setup for Defender Bot echo directories and files.
+# Creates and maintains placeholders for permissions, database, firewall, and service upgrades.
+set -euo pipefail
+
+BASE_DIR="$(git rev-parse --show-toplevel)/echo"
+
+# Create required directories
+mkdir -p "$BASE_DIR/perm" "$BASE_DIR/db" "$BASE_DIR/firewall" "$BASE_DIR/services"
+
+# Permissions file
+if [ ! -f "$BASE_DIR/perm/permissions.conf" ]; then
+  cat <<'PERM' > "$BASE_DIR/perm/permissions.conf"
+# Placeholder permissions configuration managed by Defender Bot.
+# Update with system-specific user and group rules.
+PERM
+fi
+
+# Database SQL file
+if [ ! -f "$BASE_DIR/db/database.sql" ]; then
+  cat <<'SQL' > "$BASE_DIR/db/database.sql"
+-- Placeholder SQL managed by Defender Bot.
+-- Define schema and migrations here.
+SQL
+fi
+
+# Firewall rules file
+if [ ! -f "$BASE_DIR/firewall/rules.conf" ]; then
+  cat <<'FIRE' > "$BASE_DIR/firewall/rules.conf"
+# Placeholder firewall rules managed by Defender Bot.
+# Specify allowed and blocked ports/IPs.
+FIRE
+fi
+
+# Service upgrade script
+if [ ! -f "$BASE_DIR/services/upgrade.sh" ]; then
+  cat <<'UPGRADE' > "$BASE_DIR/services/upgrade.sh"
+#!/usr/bin/env bash
+# Placeholder service upgrade script managed by Defender Bot.
+# Add service-specific upgrade commands below.
+UPGRADE
+  chmod +x "$BASE_DIR/services/upgrade.sh"
+fi
+
+# Set secure permissions
+chmod 600 "$BASE_DIR/perm/permissions.conf" "$BASE_DIR/db/database.sql" "$BASE_DIR/firewall/rules.conf"
+chmod 700 "$BASE_DIR/services/upgrade.sh"
+
+echo "[Defender Bot] Echo directories and files verified at $(date -u)"


### PR DESCRIPTION
## Summary
- integrate Microsoft Security DevOps scan and SARIF upload into Defender Bot workflow
- trigger Defender Bot on pushes, PRs, and weekly schedule for broad coverage
- run Defender Bot maintenance script after security scan

## Testing
- `bash scripts/defender_bot_workflow.sh`
- `bash scripts/check_workflows.sh` *(fails: yamllint errors in existing workflows)*

------
https://chatgpt.com/codex/tasks/task_e_689caaec36ec833290bb7163a0126911