### PR TITLE
Add Defender Watchdog workflow

### DIFF
--- a/.github/workflows/defender-watchdog.yml
+++ b/.github/workflows/defender-watchdog.yml
@@ -1,0 +1,51 @@
+name: "🔒 Defender Watchdog"
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  watchdog:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: rootpass
+          MYSQL_DATABASE: defenderdb
+          MYSQL_USER: defender
+          MYSQL_PASSWORD: defenderpass
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+        ports:
+          - 3306:3306
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install watchdog requests mysqlclient
+
+      - name: Build Docker image
+        run: docker build -t defender-bot .
+
+      - name: Run watchdog
+        run: docker run --rm defender-bot


### PR DESCRIPTION
## Summary
- schedule MySQL-backed Defender Watchdog workflow with Java, Python, and Docker setup

## Testing
- `actionlint -color .github/workflows/defender-watchdog.yml`


------
https://chatgpt.com/codex/tasks/task_e_689df0c72104833288adca73c07bcf44