### PR TITLE
Add workflow script and Rust file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ disk.img
 *.img
 .github/echo_logs/*.log
 
+
+# Rust example
+rust-example/Cargo.lock

--- a/rust-example/src/main.rs
+++ b/rust-example/src/main.rs
@@ -1,3 +1,21 @@
-fn main() {
-    println!("Hello, world!");
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() -> std::io::Result<()> {
+    let base = Path::new("../workflow");
+
+    let mut sys_file = File::create(base.join("system/app.log"))?;
+    writeln!(sys_file, "애플리케이션 로그")?;
+
+    let mut disk_file = File::create(base.join("disk/disk_usage.txt"))?;
+    writeln!(disk_file, "디스크 사용량 정보")?;
+
+    let mut container_file = File::create(base.join("container/container.log"))?;
+    writeln!(container_file, "컨테이너 로그")?;
+
+    let mut image_file = File::create(base.join("image/image_info.txt"))?;
+    writeln!(image_file, "이미지 메타데이터")?;
+
+    Ok(())
 }

--- a/scripts/workflow.sh
+++ b/scripts/workflow.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Rust if cargo is not available
+if ! command -v cargo >/dev/null 2>&1; then
+  curl https://sh.rustup.rs -sSf | sh -s -- -y
+  if [ -f "$HOME/.cargo/env" ]; then
+    source "$HOME/.cargo/env"
+  fi
+fi
+
+# Prepare directories
+mkdir -p workflow/{system,disk,container,image}
+
+# Base files
+echo "시스템 설정" > workflow/system/system.conf
+echo "디스크 정보" > workflow/disk/disk.info
+echo "컨테이너 설정" > workflow/container/container.conf
+echo "이미지 메타" > workflow/image/image.meta
+
+# Bulk file creation
+for i in {1..10}; do
+  echo "시스템 설정 $i" > workflow/system/config$i.conf
+  echo "디스크 정보 $i" > workflow/disk/disk$i.info
+  echo "컨테이너 설정 $i" > workflow/container/ctr$i.conf
+  echo "이미지 메타 $i" > workflow/image/img$i.meta
+done
+
+# Build and run Rust project to generate additional files
+(
+  cd rust-example
+  cargo build --release
+  cargo run --release
+)


### PR DESCRIPTION
## Summary
- ignore rust-example Cargo.lock
- create workflow script that installs Rust, generates directories/files, and runs the Rust example
- extend Rust example to output system/disk/container/image log files

## Testing
- `bash scripts/workflow.sh`
- `cargo test --manifest-path rust-example/Cargo.toml`
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_689df44cc3e88332949282c53ec8ed18