### PR TITLE
Add DB CLI Remake Automation workflow

### DIFF
--- a/.github/workflows/defender-db-cli-remake.yml
+++ b/.github/workflows/defender-db-cli-remake.yml
@@ -1,0 +1,109 @@
+---
+name: "\U0001F6E1\uFE0F Defender Bot - DB CLI Remake Automation"
+
+"on":
+  push:
+    branches: ["main"]
+  pull_request:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  db-cli-remake-batch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    env:
+      DBCLI_DIR: .github/dbcli
+      OUTPUT_DIR: .github/dbcli/output
+      VA_DIR: .github/dbcli/virtual_accounts
+      ORDER_DIR: .github/dbcli/orders
+      USER_DIR: .github/dbcli/users
+      TMP_SAFE_DIR: /tmp/dbcli_safe_tmp
+      DB2_CLI_URL: "https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/linuxx64_odbc_cli.tar.gz"
+      DB2_CLI_DIR: /opt/ibm/db2_cli
+      MIN_FREE_MB: 500
+
+    steps:
+      - name: "📦 Checkout"
+        uses: actions/checkout@v5
+
+      - name: robust 디렉토리/파일 생성 샘플
+        shell: bash
+        run: |
+          set -e
+          robust_mkdir() {
+            DIR="$1"
+            if [ -e "$DIR" ] && [ ! -d "$DIR" ]; then
+              echo "[⚠️][robust] $DIR: 파일이 디렉토리 이름과 충돌, 파일 삭제"
+              rm -f "$DIR"
+            fi
+            mkdir -p "$DIR"
+            chmod 700 "$DIR"
+          }
+          robust_echo() {
+            CONTENT="$1"
+            TARGET="$2"
+            DIR=$(dirname "$TARGET")
+            robust_mkdir "$DIR"
+            if [ -e "$TARGET" ]; then
+              if [ -d "$TARGET" ]; then
+                echo "[⚠️][에러] $TARGET (echo 대상이 디렉토리, robust_rm로 삭제 후 파일 생성)"
+                rm -rf "$TARGET"
+              else
+                rm -f "$TARGET"
+              fi
+            fi
+            echo "$CONTENT" > "$TARGET"
+            chmod 600 "$TARGET"
+            echo "[✅][robust] $TARGET robust echo 파일 생성 성공"
+          }
+          # DB/CLI/샘플 robust
+          for DB in mysql mariadb percona postgresql sqlite redis clickhouse firebird db2; do
+            robust_mkdir "$DBCLI_DIR/$DB"
+          done
+          robust_mkdir "$OUTPUT_DIR"
+          robust_mkdir "$VA_DIR"
+          robust_mkdir "$TMP_SAFE_DIR"
+          robust_mkdir "$ORDER_DIR"
+          robust_mkdir "$USER_DIR"
+          robust_echo "SELECT VERSION();"        $DBCLI_DIR/mysql/demo.sql
+          robust_echo "SELECT VERSION();"        $DBCLI_DIR/mariadb/demo.sql
+          robust_echo "SELECT VERSION();"        $DBCLI_DIR/percona/demo.sql
+          robust_echo "SELECT version();"        $DBCLI_DIR/postgresql/demo.sql
+          robust_echo "SELECT sqlite_version();" $DBCLI_DIR/sqlite/demo.sql
+          robust_echo "PING"                     $DBCLI_DIR/redis/demo.redis
+          robust_echo "SELECT version();"        $DBCLI_DIR/clickhouse/demo.sql
+          robust_echo "SELECT * FROM RDB\$DATABASE;" $DBCLI_DIR/firebird/demo.sql
+          robust_echo "SELECT service_level, fixpack_num FROM sysibmadm.env_inst_info;" $DBCLI_DIR/db2/demo.sql
+          # 가상계좌 더미 robust
+          robust_echo "user_id,user_name,permission,enabled" "$USER_DIR/users.csv"
+          echo "[🧹][∞][리메이크] 기존 가상계좌 파일 전체 삭제"
+          rm -f $VA_DIR/virtual_accounts_*.txt
+          TS=$(date '+%Y%m%d_%H%M%S')
+          VA_FILE="$TMP_SAFE_DIR/virtual_accounts_${TS}_$$.txt"
+          robust_echo "account_id,account_number,customer_name,bank_code,open_date" "$VA_FILE"
+          for i in $(seq 1 10000); do
+            ACC_NUM="7000$(printf '%07d' $i)"
+            CUST="User$(printf '%05d' $i)"
+            BANK="B$(printf '%04d' $((1000 + ($i % 9000))))"
+            DATE="$(date '+%Y-%m-%d')"
+            echo "VA${i},${ACC_NUM},${CUST},${BANK},${DATE}" >> "$VA_FILE"
+          done
+          chmod 600 "$VA_FILE"
+          mv "$VA_FILE" "$VA_DIR/"
+          echo "[✅][∞][리메이크] $VA_FILE → $VA_DIR 이동 및 권한 최소화"
+          ls -lh $VA_DIR/virtual_accounts_*.txt
+          rm -rf $TMP_SAFE_DIR
+      - name: 최신 DB CLI 추가 설치 (옵션, 에러 무시)
+        run: |
+          sudo apt-get install -y mysql-client-8.0 mysql-client-core-8.0 mariadb-client-10.6 || true
+          sudo apt-get install -y postgresql-client-16 postgresql-client-common || true
+          sudo apt-get install -y clickhouse-client || true
+          sudo apt-get install -y firebird-utils || true


### PR DESCRIPTION
## Summary
- add DB CLI Remake Automation GitHub Actions workflow for robust directory setup and optional CLI installs
- expand workflow triggers and permissions to follow Defender Bot conventions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dfd7cc0ac83329532d7d521f94446