### PR TITLE
Add Docker account rotation workflow

### DIFF
--- a/workflow/Dockerfile
+++ b/workflow/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip cron sudo openssl
+
+COPY bootstrap.sh /usr/local/bin/bootstrap.sh
+COPY rotate_accounts.py /usr/local/bin/rotate_accounts.py
+
+RUN chmod +x /usr/local/bin/bootstrap.sh \
+    && chmod +x /usr/local/bin/rotate_accounts.py
+
+ENTRYPOINT ["/usr/local/bin/bootstrap.sh"]

--- a/workflow/automation.sh
+++ b/workflow/automation.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+IMAGE_NAME="workflow-image"
+CONTAINER_NAME="workflow-container"
+VOLUME_PREFIX="data_volume"
+
+# 이미지 빌드
+docker build -t "$IMAGE_NAME" .
+
+# 볼륨 10개 생성
+for i in {1..10}; do
+  docker volume create "${VOLUME_PREFIX}_${i}"
+done
+
+# 컨테이너 실행
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -v "${VOLUME_PREFIX}_1:/data" \
+  "$IMAGE_NAME"
+
+echo "[automation] 컨테이너와 볼륨 생성 완료"

--- a/workflow/bootstrap.sh
+++ b/workflow/bootstrap.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+USERNAME="worker"
+PASSWORD="$(openssl rand -base64 12)"
+
+useradd -m -s /bin/bash "$USERNAME"
+echo "$USERNAME:$PASSWORD" | chpasswd
+usermod -aG sudo "$USERNAME"
+
+echo "초기 사용자/패스워드:"
+echo "$USERNAME / $PASSWORD"
+
+echo "0 0 * * * /usr/local/bin/rotate_accounts.py >> /var/log/rotate_accounts.log 2>&1" | crontab -
+
+service cron start
+tail -f /dev/null

--- a/workflow/rotate_accounts.py
+++ b/workflow/rotate_accounts.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import secrets
+import base64
+import subprocess
+
+USERNAME = "worker"
+
+def rotate_password():
+    new_pwd = base64.b64encode(secrets.token_bytes(12)).decode()
+    subprocess.run(["chpasswd"], input=f"{USERNAME}:{new_pwd}".encode(), check=True)
+    print(f"[rotate_accounts] {USERNAME} 새 비밀번호: {new_pwd}")
+
+if __name__ == "__main__":
+    rotate_password()


### PR DESCRIPTION
## Summary
- add Docker workflow to build container, volumes, and rotate account passwords on a schedule

## Testing
- `python3 -m py_compile workflow/rotate_accounts.py`
- `bash -n workflow/bootstrap.sh`
- `bash -n workflow/automation.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689edee9c43c8332afb5e5f063202335