### PR TITLE
Add workflow to refresh program data

### DIFF
--- a/.github/workflows/update-program-data.yml
+++ b/.github/workflows/update-program-data.yml
@@ -1,0 +1,15 @@
+name: Update Program Data
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # 매주 일요일 00:00 UTC
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Refresh data for all programs
+        run: bash workflow/update_all_data.sh

--- a/workflow/update_all_data.sh
+++ b/workflow/update_all_data.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Update data for all known programs in this repository.
+# This script writes a timestamped file under the data/ directory for
+# each program to indicate when it was refreshed.
+set -euo pipefail
+
+# List of program directories to update
+PROGRAMS=(
+  "bulk"
+  "finance_app"
+  "rust-example"
+  "src"
+)
+
+DATA_DIR="$(cd "$(dirname "$0")/.." && pwd)/data"
+mkdir -p "$DATA_DIR"
+
+for prog in "${PROGRAMS[@]}"; do
+  if [ -d "$prog" ]; then
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    echo "$timestamp" > "$DATA_DIR/${prog}_last_updated.txt"
+    echo "[update] $prog -> $timestamp"
+  else
+    echo "[skip] $prog (directory not found)"
+  fi
+done


### PR DESCRIPTION
## Summary
- add script to refresh timestamps for program data
- add workflow to run refresh script on schedule or manual dispatch

## Testing
- `bash -n workflow/update_all_data.sh`
- `bash workflow/update_all_data.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a0718aa9e48332b0412840e6328a4d