### PR TITLE
feat: schedule rerun for all workflows

### DIFF
--- a/.github/workflows/force-rerun.yml
+++ b/.github/workflows/force-rerun.yml
@@ -1,0 +1,52 @@
+name: Rerun All Workflows
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger every workflow
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const currentWorkflowPath = '.github/workflows/force-rerun.yml';
+            const workflows = await github.paginate(
+              github.rest.actions.listWorkflows,
+              { owner, repo, per_page: 100 },
+              (response) => response.data.workflows
+            );
+            for (const wf of workflows) {
+              if (!wf.id || wf.path === currentWorkflowPath) continue;
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: wf.id,
+                per_page: 1
+              });
+              if (runs.data.workflow_runs.length > 0) {
+                await github.rest.actions.reRunWorkflow({
+                  owner,
+                  repo,
+                  run_id: runs.data.workflow_runs[0].id
+                });
+              } else {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: wf.id,
+                  ref: context.ref
+                });
+              }
+            }
+


### PR DESCRIPTION
## Summary
- add workflow that reruns all other workflows hourly and via manual dispatch
- fix pagination to properly iterate through all workflows and skip self rerun

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a07e18ccc483328a9038026489952c