### PR TITLE
Add workflow for generating virtual credential files

### DIFF
--- a/.github/workflows/virtual-credentials.yml
+++ b/.github/workflows/virtual-credentials.yml
@@ -1,0 +1,29 @@
+name: "\U0001F510 Virtual Credentials Generator"
+
+on:
+  workflow_dispatch:
+    inputs:
+      run:
+        description: 'Generate virtual account, password and permission files'
+        required: false
+        default: 'run'
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "\U0001F4E6 Checkout repository"
+        uses: actions/checkout@v5
+
+      - name: "\U0001F527 Generate virtual credentials"
+        run: |
+          mkdir -p virtual
+          echo "account-$(date +%s)" > virtual/account.txt
+          openssl rand -hex 16 > virtual/password.txt
+          printf "read\nwrite\nexecute\n" > virtual/permission.txt
+
+      - name: "\U0001F4E4 Upload virtual credentials"
+        uses: actions/upload-artifact@v4
+        with:
+          name: virtual-credentials
+          path: virtual/


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to create virtual account, password, and permission files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0803d13248332bc19f5a2c4b54cf0