### PR TITLE
chore(ci): add echo-enabled workflow health check

### DIFF
--- a/.github/workflows/workflows-health-check-echo.yml
+++ b/.github/workflows/workflows-health-check-echo.yml
@@ -1,0 +1,247 @@
+name: "🩺 Workflows Health Check (24x7 + Echo Everywhere)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      lookback:
+        description: "최근 조회 실행 수 (기본 24)"
+        required: false
+        default: "24"
+      max_reruns:
+        description: "자동 재실행 최대 횟수/회 (기본 3)"
+        required: false
+        default: "3"
+      fail_rate_threshold:
+        description: "실패율 임계값 (0~1, 기본 0.5)"
+        required: false
+        default: "0.5"
+      fail_abs_threshold:
+        description: "절대 실패 횟수 임계값 (기본 3)"
+        required: false
+        default: "3"
+      replica_count:
+        description: "랩 복제본 개수 (기본 5)"
+        required: false
+        default: "5"
+      commit_changes:
+        description: "변경 커밋/푸시 여부 (true/false, 기본 true)"
+        required: false
+        default: "true"
+  schedule:
+    - cron: "0 * * * *" # 매시간 정각(UTC)
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  health-check:
+    name: "Health Check (EchoOps)"
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LOG_DIR: .github/logs
+      LAB_DIR: ci-labs/replicas
+      QUAR_DIR: ci-labs/quarantine
+      LOOKBACK_DEFAULT: "24"
+      MAX_RERUNS_DEFAULT: "3"
+      FAIL_RATE_THRESHOLD_DEFAULT: "0.5"
+      FAIL_ABS_THRESHOLD_DEFAULT: "3"
+      REPLICA_COUNT_DEFAULT: "5"
+      COMMIT_CHANGES_DEFAULT: "true"
+
+    steps:
+      - name: 🛠️ Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: 🧰 Install gh & jq
+        shell: bash
+        run: |
+          set -e
+          ts(){ date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+          ECHO(){ printf '%s [%s] %s\n' "$(ts)" "$1" "$2"; }
+          ECHO INFO "apt update"
+          sudo apt-get update -y -qq
+          ECHO INFO "install gh jq"
+          sudo apt-get install -y -qq gh jq
+          ECHO OK   "tools ready"
+
+      - name: 📂 Prepare dirs (echo)
+        shell: bash
+        run: |
+          set -e
+          ts(){ date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+          ECHO(){ printf '%s [%s] %s\n' "$(ts)" "$1" "$2"; }
+          ECHO INFO "mkdir -p $LOG_DIR $LAB_DIR $QUAR_DIR"
+          mkdir -p "$LOG_DIR" "$LAB_DIR" "$QUAR_DIR"
+          echo "# Workflows Health Logs ($(ts))" > "$LOG_DIR/health_report.md"
+          ECHO OK   "dirs prepared"
+
+      - name: 🔍 Health check + auto-rerun + labs/quarantine (echo)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          ts(){ date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+          ECHO(){ printf '%s [%s] %s\n' "$(ts)" "$1" "$2"; }
+
+          LOOKBACK="${{ github.event.inputs.lookback || env.LOOKBACK_DEFAULT }}"
+          MAX_RERUNS="${{ github.event.inputs.max_reruns || env.MAX_RERUNS_DEFAULT }}"
+          FAIL_RATE_THRESHOLD="${{ github.event.inputs.fail_rate_threshold || env.FAIL_RATE_THRESHOLD_DEFAULT }}"
+          FAIL_ABS_THRESHOLD="${{ github.event.inputs.fail_abs_threshold || env.FAIL_ABS_THRESHOLD_DEFAULT }}"
+          REPLICA_COUNT="${{ github.event.inputs.replica_count || env.REPLICA_COUNT_DEFAULT }}"
+          COMMIT_CHANGES="${{ github.event.inputs.commit_changes || env.COMMIT_CHANGES_DEFAULT }}"
+
+          REPORT_MD="$LOG_DIR/health_report.md"
+          {
+            echo ""
+            echo "# 🩺 Workflows Health Check Report ($(ts))"
+            echo ""
+            echo "| Workflow | Runs | OK | Fail | Cancel | FailRate | Last | ReRuns | Action |"
+            echo "|---|---:|---:|---:|---:|---:|---|---:|---|"
+          } >> "$REPORT_MD"
+
+          ECHO INFO "params LOOKBACK=$LOOKBACK MAX_RERUNS=$MAX_RERUNS RATE_TH=$FAIL_RATE_THRESHOLD ABS_TH=$FAIL_ABS_THRESHOLD REPLICA=$REPLICA_COUNT COMMIT=$COMMIT_CHANGES"
+
+          TOTAL_RERUNS=0
+          FAILED_WORKFLOWS=()
+
+          shopt -s nullglob
+          for file in .github/workflows/*.{yml,yaml}; do
+            WF_FILE="$(basename "$file")"
+            ECHO INFO "check $WF_FILE"
+
+            RUNS_JSON="$(gh run list --workflow "$WF_FILE" --limit "$LOOKBACK" --json databaseId,conclusion,status,createdAt,headBranch 2>/dev/null || true)"
+            RUNS_COUNT="$(jq 'length' <<< "$RUNS_JSON" 2>/dev/null || echo 0)"
+
+            if [[ -z "$RUNS_JSON" || "$RUNS_COUNT" -eq 0 ]]; then
+              ECHO WARN "no runs for $WF_FILE"
+              echo "| \`$WF_FILE\` | 0 | 0 | 0 | 0 | 0.00 | N/A | 0 | no-runs |" >> "$REPORT_MD"
+              continue
+            fi
+
+            SUC="$(jq '[.[] | select(.conclusion=="success")] | length' <<< "$RUNS_JSON")"
+            FAI="$(jq '[.[] | select(.conclusion=="failure")] | length' <<< "$RUNS_JSON")"
+            CAN="$(jq '[.[] | select(.conclusion=="cancelled")] | length' <<< "$RUNS_JSON")"
+            LAST_CONC="$(jq -r '.[0].conclusion // "unknown"' <<< "$RUNS_JSON")"
+
+            # 실패율 계산
+            FAIL_RATE=$(python3 - <<PY
+ total=$RUNS_COUNT
+ fail=$FAI
+ print(f"{(fail/total):.2f}" if total>0 else "0.00")
+PY
+)
+            ECHO INFO "$WF_FILE runs=$RUNS_COUNT ok=$SUC fail=$FAI cancel=$CAN rate=$FAIL_RATE last=$LAST_CONC"
+
+            # 최근 실패/취소 자동 재실행
+            RERUNS=0
+            if [[ "$MAX_RERUNS" -gt 0 ]]; then
+              while read -r run_id; do
+                [[ -z "$run_id" ]] && continue
+                ECHO INFO "rerun $run_id for $WF_FILE"
+                gh run rerun "$run_id" || ECHO WARN "rerun failed id=$run_id"
+                RERUNS=$((RERUNS+1))
+                TOTAL_RERUNS=$((TOTAL_RERUNS+1))
+                [[ "$RERUNS" -ge "$MAX_RERUNS" ]] && break
+              done < <(jq -r '[.[] | select((.conclusion=="failure") or (.conclusion=="cancelled")) | .databaseId] | .[]?' <<< "$RUNS_JSON")
+            fi
+
+            # 임계 판단
+            OVER_RATE=$(python3 - <<PY
+print("1" if float("$FAIL_RATE") >= float("$FAIL_RATE_THRESHOLD") else "0")
+PY
+)
+            OVER_ABS=$(python3 - <<PY
+print("1" if int("$FAI") >= int("$FAIL_ABS_THRESHOLD") else "0")
+PY
+)
+
+            ACTION="ok"
+            if [[ "$OVER_RATE" == "1" || "$OVER_ABS" == "1" ]]; then
+              ACTION="labs/quarantine"
+              FAILED_WORKFLOWS+=("$WF_FILE")
+
+              WF_BASE="${WF_FILE%.*}"
+              TS_ID="$(ts | tr ':T' '__' | tr -d 'Z')"
+
+              # 랩 복제본 생성 (workflow_dispatch만 허용)
+              LAB_ROOT="$LAB_DIR/${WF_BASE}/${TS_ID}"
+              mkdir -p "$LAB_ROOT"
+              for i in $(seq 1 "$REPLICA_COUNT"); do
+                LAB_COPY="$LAB_ROOT/${WF_BASE}-lab-${i}.yml"
+                ECHO INFO "create lab replica $LAB_COPY"
+                awk '
+                  BEGIN {in_on=0}
+                  /^[[:space:]]*on:[[:space:]]*$/ {print "on:\n  workflow_dispatch:"; in_on=1; next}
+                  {if(in_on && $0 ~ /^[[:space:]]*[^[:space:]]/){in_on=0} if(!in_on) print}
+                ' "$file" > "$LAB_COPY"
+                # 이름 수정
+                if grep -q '^name:' "$LAB_COPY"; then
+                  sed -i "1s|^name:.*|name: ${WF_BASE} (LAB ${i})|" "$LAB_COPY"
+                else
+                  sed -i "1i name: ${WF_BASE} (LAB ${i})" "$LAB_COPY"
+                fi
+              done
+
+              # 격리 백업(원본 그대로)
+              QUAR_ROOT="$QUAR_DIR/${WF_BASE}/${TS_ID}"
+              mkdir -p "$QUAR_ROOT"
+              QUAR_COPY="$QUAR_ROOT/$WF_FILE"
+              ECHO INFO "backup quarantine $QUAR_COPY"
+              cp -f "$file" "$QUAR_COPY"
+            fi
+
+            echo "| \`$WF_FILE\` | $RUNS_COUNT | $SUC | $FAI | $CAN | $FAIL_RATE | $LAST_CONC | $RERUNS | $ACTION |" >> "$REPORT_MD"
+          done
+
+          {
+            echo ""
+            echo "## Summary ($(ts))"
+            echo "- Total auto reruns attempted: **$TOTAL_RERUNS**"
+            if [[ ${#FAILED_WORKFLOWS[@]} -gt 0 ]]; then
+              echo "- Labs/Quarantine 대상: \`${FAILED_WORKFLOWS[*]}\`"
+            else
+              echo "- 모든 워크플로우 임계 미만"
+            fi
+          } >> "$REPORT_MD"
+
+          # 콘솔/요약에도 복사
+          cat "$REPORT_MD" | sed 's/^/[ECHO] /' || true
+          cat "$REPORT_MD" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 💾 Commit & Push generated labs/quarantine & report (echo)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          ts(){ date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+          ECHO(){ printf '%s [%s] %s\n' "$(ts)" "$1" "$2"; }
+
+          COMMIT_CHANGES="${{ github.event.inputs.commit_changes || env.COMMIT_CHANGES_DEFAULT }}"
+          if [[ "$COMMIT_CHANGES" != "true" ]]; then
+            ECHO INFO "commit_changes=false → 커밋/푸시 생략"
+            exit 0
+          fi
+
+          if git diff --quiet; then
+            ECHO INFO "no changes to commit"
+            exit 0
+          fi
+
+          ECHO INFO "git commit"
+          git config user.name  "workflow-bot"
+          git config user.email "workflow-bot@users.noreply.github.com"
+          git add -A
+          git commit -m "chore(health): labs/quarantine & report ($(ts))"
+          ECHO INFO "git push"
+          git push origin "HEAD:${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}" || true
+          ECHO OK   "pushed"
+
+      - name: 📎 Upload report & logs (echo)
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflows-health-${{ github.run_id }}
+          path: .github/logs
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- add 24x7 workflow health check with echo logging
- auto-rerun failed workflows and archive to labs/quarantine

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a083c59348833281b4e72ee1c1daff