### PR TITLE
Add automated cleanup for failed workflow runs

### DIFF
--- a/.github/workflows/delete-failed-workflow-runs.yml
+++ b/.github/workflows/delete-failed-workflow-runs.yml
@@ -9,38 +9,14 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     permissions:
-      actions: write # <--- This line is crucial for deleting workflow runs
+      actions: write # Required for deleting and disabling workflow runs
     steps:
-      - name: Delete failed workflow runs
-        uses: actions/github-script@v7
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const perPage = 50;
-            let page = 1;
-            while (true) {
-              const runs = await github.rest.actions.listWorkflowRunsForRepo({
-                owner,
-                repo,
-                status: 'completed',
-                per_page: perPage,
-                page,
-              });
-              if (runs.data.workflow_runs.length === 0) {
-                break;
-              }
-              for (const run of runs.data.workflow_runs) {
-                if (run.conclusion === 'failure') {
-                  await github.rest.actions.deleteWorkflowRun({
-                    owner,
-                    repo,
-                    run_id: run.id,
-                  });
-                  console.log(`Deleted failed run ${run.id}`);
-                }
-              }
-              page += 1;
-            }
+          python-version: '3.x'
+      - name: Delete and disable failed workflow runs
+        run: python scripts/delete_and_disable_failed_workflows.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}

--- a/scripts/delete_and_disable_failed_workflows.py
+++ b/scripts/delete_and_disable_failed_workflows.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Delete failed GitHub workflow runs and disable their workflows.
+
+This script interacts with the GitHub REST API to find completed workflow
+runs that concluded with failure. For each such run it deletes the run and
+then disables the workflow that produced it. A workflow is disabled only once
+per execution to avoid redundant API calls.
+
+Required environment variables:
+- GITHUB_TOKEN: token with `actions:write` permission
+- REPO: in the form "owner/repo"
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import requests
+
+API_ROOT = "https://api.github.com"
+TOKEN = os.environ.get("GITHUB_TOKEN")
+REPO = os.environ.get("REPO")
+
+if not TOKEN or not REPO:
+    print("GITHUB_TOKEN and REPO environment variables must be set", file=sys.stderr)
+    sys.exit(1)
+
+OWNER, REPO_NAME = REPO.split("/")
+
+session = requests.Session()
+session.headers.update(
+    {
+        "Authorization": f"token {TOKEN}",
+        "Accept": "application/vnd.github+json",
+    }
+)
+
+per_page = 50
+page = 1
+disabled_workflows: set[int] = set()
+
+while True:
+    resp = session.get(
+        f"{API_ROOT}/repos/{OWNER}/{REPO_NAME}/actions/runs",
+        params={"status": "completed", "per_page": per_page, "page": page},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    runs = resp.json().get("workflow_runs", [])
+    if not runs:
+        break
+
+    for run in runs:
+        if run.get("conclusion") != "failure":
+            continue
+
+        run_id = run["id"]
+        workflow_id = run["workflow_id"]
+
+        del_resp = session.delete(
+            f"{API_ROOT}/repos/{OWNER}/{REPO_NAME}/actions/runs/{run_id}", timeout=30
+        )
+        if del_resp.status_code == 204:
+            print(f"Deleted failed run {run_id}")
+        else:
+            print(f"Failed to delete run {run_id}: {del_resp.status_code}", file=sys.stderr)
+
+        if workflow_id not in disabled_workflows:
+            dis_resp = session.put(
+                f"{API_ROOT}/repos/{OWNER}/{REPO_NAME}/actions/workflows/{workflow_id}/disable",
+                timeout=30,
+            )
+            if dis_resp.status_code == 204:
+                print(f"Disabled workflow {workflow_id}")
+                disabled_workflows.add(workflow_id)
+            else:
+                print(
+                    f"Failed to disable workflow {workflow_id}: {dis_resp.status_code}",
+                    file=sys.stderr,
+                )
+
+    page += 1


### PR DESCRIPTION
## Summary
- add Python utility to delete failed workflow runs and disable their workflows
- wire the cleanup script into the daily cleanup workflow

## Testing
- `python -m py_compile scripts/delete_and_disable_failed_workflows.py`
- `bash scripts/check_workflows.sh` *(fails: line too long errors in existing workflow files)*
- `yamllint .github/workflows/delete-failed-workflow-runs.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a13463b3ec8332a1f18dbf1031b7f8