### PR TITLE
Add workflow analysis helper and modernize dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 
 updates:
@@ -8,6 +9,7 @@ updates:
       time: "21:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 10
+    rebase-strategy: auto
     commit-message:
       prefix: "deps(actions)"
       include: "scope"
@@ -22,6 +24,7 @@ updates:
       time: "21:10"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 10
+    rebase-strategy: auto
     commit-message:
       prefix: "deps(docker)"
       include: "scope"
@@ -36,6 +39,7 @@ updates:
       time: "21:20"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 10
+    rebase-strategy: auto
     commit-message:
       prefix: "deps(pip)"
       include: "scope"
@@ -44,17 +48,18 @@ updates:
       pip-all:
         patterns: ["*"]
 
-  # 필요시 주석 해제
-  # - package-ecosystem: "npm"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "daily"
-  #     time: "21:30"
-  #     timezone: "Asia/Seoul"
-  #   open-pull-requests-limit: 10
-  #   commit-message:
-  #     prefix: "deps(npm)"
-  #     include: "scope"
-  #   groups:
-  #     npm-all:
-  #       patterns: ["*"]
+# 필요시 주석 해제
+# - package-ecosystem: "npm"
+#   directory: "/"
+#   schedule:
+#     interval: "daily"
+#     time: "21:30"
+#     timezone: "Asia/Seoul"
+#   open-pull-requests-limit: 10
+#   rebase-strategy: auto
+#   commit-message:
+#     prefix: "deps(npm)"
+#     include: "scope"
+#   groups:
+#     npm-all:
+#       patterns: ["*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31
+PyYAML>=6.0

--- a/scripts/workflow_analyzer.py
+++ b/scripts/workflow_analyzer.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Analyze GitHub workflows and trigger Dependabot updates.
+
+This utility helps investigate the latest run of each GitHub Actions workflow
+in a repository and provides commands to trigger Dependabot update jobs for
+individual ecosystems or all configured ones. It uses the GitHub REST API.
+
+Environment variables:
+- GITHUB_TOKEN: Personal access token with `repo` and `workflow` scopes.
+- REPO: Repository in the form "owner/repo". Defaults to "davidkims/springboot".
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Iterable
+
+import requests
+import yaml
+
+API_ROOT = "https://api.github.com"
+TOKEN = os.environ.get("GITHUB_TOKEN")
+REPO = os.environ.get("REPO", "davidkims/springboot")
+
+if not TOKEN:
+    print("GITHUB_TOKEN environment variable must be set", file=sys.stderr)
+    sys.exit(1)
+
+SESSION = requests.Session()
+SESSION.headers.update(
+    {
+        "Authorization": f"token {TOKEN}",
+        "Accept": "application/vnd.github+json",
+    }
+)
+
+
+def fetch_json(url: str, **kwargs) -> dict:
+    """GET helper returning JSON with error handling."""
+    resp = SESSION.get(url, timeout=30, **kwargs)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def list_workflows() -> Iterable[dict]:
+    """Return an iterable of workflow metadata objects."""
+    data = fetch_json(f"{API_ROOT}/repos/{REPO}/actions/workflows")
+    return data.get("workflows", [])
+
+
+def analyze_workflows() -> None:
+    """Print the last run status for each workflow and failing step if any."""
+    for wf in list_workflows():
+        wf_id = wf.get("id")
+        wf_name = wf.get("name")
+        runs_url = f"{API_ROOT}/repos/{REPO}/actions/workflows/{wf_id}/runs"
+        runs = fetch_json(runs_url, params={"per_page": 1}).get("workflow_runs", [])
+        if not runs:
+            print(f"{wf_name}: no runs")
+            continue
+        run = runs[0]
+        conclusion = run.get("conclusion")
+        run_id = run.get("id")
+        print(f"{wf_name}: {conclusion}")
+        if conclusion != "failure":
+            continue
+        jobs_url = f"{API_ROOT}/repos/{REPO}/actions/runs/{run_id}/jobs"
+        jobs = fetch_json(jobs_url).get("jobs", [])
+        for job in jobs:
+            for step in job.get("steps", []):
+                if step.get("conclusion") == "failure":
+                    print(f"  failing step: {step.get('name')}")
+                    break
+            else:
+                continue
+            break
+
+
+def trigger_dependabot_update(ecosystem: str, directory: str) -> None:
+    """Trigger a Dependabot update job for the given ecosystem and directory."""
+    url = f"{API_ROOT}/repos/{REPO}/dependabot/updates"
+    payload = {"package-ecosystem": ecosystem, "directory": directory}
+    resp = SESSION.post(url, json=payload, timeout=30)
+    if resp.status_code == 201:
+        print(f"Triggered Dependabot update for {ecosystem} ({directory})")
+    else:
+        print(
+            f"Failed to trigger update for {ecosystem} ({directory}): {resp.status_code}",
+            file=sys.stderr,
+        )
+        print(resp.text)
+
+
+def load_dependabot_updates(path: str = ".github/dependabot.yml") -> Iterable[dict]:
+    """Load update configurations from Dependabot config file."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("updates", [])
+
+
+def trigger_all_updates() -> None:
+    """Trigger Dependabot updates for all configured ecosystems."""
+    for upd in load_dependabot_updates():
+        ecosystem = upd.get("package-ecosystem")
+        directory = upd.get("directory")
+        if ecosystem and directory:
+            trigger_dependabot_update(ecosystem, directory)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("analyze", help="Analyze latest workflow runs")
+
+    upd = sub.add_parser("update", help="Trigger Dependabot update")
+    upd.add_argument("ecosystem", help="package ecosystem, e.g. pip")
+    upd.add_argument("directory", help="directory where the manifest lives")
+
+    sub.add_parser("update-all", help="Trigger Dependabot updates for all configured ecosystems")
+
+    args = parser.parse_args()
+    if args.command == "analyze":
+        analyze_workflows()
+    elif args.command == "update":
+        trigger_dependabot_update(args.ecosystem, args.directory)
+    elif args.command == "update-all":
+        trigger_all_updates()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `workflow_analyzer.py` utility to inspect GitHub Actions runs and trigger Dependabot updates per ecosystem
- Enable automatic rebasing in dependabot config and add YAML document header
- Extend workflow analyzer with bulk update command and declare Python dependencies

## Testing
- `yamllint .github/dependabot.yml`
- `python -m py_compile scripts/workflow_analyzer.py`
- `GITHUB_TOKEN=foo scripts/workflow_analyzer.py --help`
- `GITHUB_TOKEN=foo scripts/workflow_analyzer.py update-all`


------
https://chatgpt.com/codex/tasks/task_e_68a481bcc2c08332969b6c91eb33197d