### PR TITLE
Fix ISO build heredoc delimiters in workflow

### DIFF
--- a/.github/workflows/WorkflowsHealthCheck.yml
+++ b/.github/workflows/WorkflowsHealthCheck.yml
@@ -803,7 +803,7 @@ jobs:
                   configfile (cd0)/EFI/BOOT/grub.cfg.orig
                 fi
             }
-            GRUB
+          GRUB
 
             xorriso -indev "${OUT}/base-ubuntu.iso" -outdev "${OUT}/base-ubuntu-with-seed-autoinstall.iso" \
               -map "${ECHO_ROOT}/iso_src/seed" /seed \
@@ -849,7 +849,7 @@ jobs:
               -map "${ECHO_ROOT}/iso_src/extras" /extras \
               -boot_image any keep
 
-            rm -rf "${ECHO_ROOT}/tmp/grub" && mkdir -p "${ECHO_ROOT}/tmp/grub/boot/grub" "${ECHO_ROOT}/tmp/grub/EFI/BOOT}"
+            rm -rf "${ECHO_ROOT}/tmp/grub" && mkdir -p "${ECHO_ROOT}/tmp/grub/boot/grub" "${ECHO_ROOT}/tmp/grub/EFI/BOOT"
             7z x -o"${ECHO_ROOT}/tmp/grub" "${OUT}/base-debian.iso" boot/grub/grub.cfg EFI/BOOT/grub.cfg -y || true
             [ -f "${ECHO_ROOT}/tmp/grub/boot/grub/grub.cfg" ] || touch "${ECHO_ROOT}/tmp/grub/boot/grub/grub.cfg"
             [ -f "${ECHO_ROOT}/tmp/grub/EFI/BOOT/grub.cfg" ]  || touch "${ECHO_ROOT}/tmp/grub/EFI/BOOT/grub.cfg"
@@ -871,7 +871,7 @@ jobs:
                   configfile (cd0)/EFI/BOOT/grub.cfg.orig
                 fi
             }
-            GRUB
+          GRUB
 
             xorriso -indev "${OUT}/base-debian.iso" -outdev "${OUT}/base-debian-with-seed-autoinstall.iso" \
               -map "${ECHO_ROOT}/iso_src/seed" /seed \
@@ -964,7 +964,7 @@ jobs:
                   configfile (cd0)/EFI/BOOT/grub.cfg.orig
                 fi
             }
-            GRUB
+          GRUB
 
             xorriso -indev "${BASEISO}" -outdev "${OUT}/base-${PREFIX}-with-seed-autoinstall.iso" \
               -map "${ECHO_ROOT}/iso_src/seed" /seed \


### PR DESCRIPTION
## Summary
- dedent here-doc GRUB terminators to avoid syntax errors
- fix Debian grub directory path

## Testing
- `python -m pytest`
- `yamllint .github/workflows/WorkflowsHealthCheck.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c9b488f08332945177c68a285899