### PR TITLE
Add simulated Teradata workflow with echo logging

### DIFF
--- a/echo/db/teradata_echo.sql
+++ b/echo/db/teradata_echo.sql
@@ -1,0 +1,10 @@
+-- Teradata echo table used to store installation details
+CREATE TABLE IF NOT EXISTS echo_installation (
+    id INTEGER GENERATED ALWAYS AS IDENTITY,
+    step VARCHAR(255),
+    status VARCHAR(32),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Example query to list installation steps
+SELECT * FROM echo_installation ORDER BY created_at;

--- a/scripts/teradata_workflow.sh
+++ b/scripts/teradata_workflow.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# teradata_workflow.sh - Simulated workflow script for Teradata installation and DW setup.
+# This script demonstrates how a workflow could automate installation and configuration
+# steps with extensive echo logging to trace progress.
+
+set -euo pipefail
+
+# Determine project root relative to this script
+BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ECHO_DIR="${BASE_DIR}/echo/teradata"
+LOG_FILE="${ECHO_DIR}/install.log"
+SQL_FILE="${BASE_DIR}/echo/db/teradata_echo.sql"
+
+mkdir -p "${ECHO_DIR}/services" "${ECHO_DIR}/perm"
+echo "Starting Teradata workflow" | tee "${LOG_FILE}"
+
+install_teradata() {
+    echo "Simulating Teradata installation..." | tee -a "${LOG_FILE}"
+    echo "(Actual installation commands would be placed here)" | tee -a "${LOG_FILE}"
+}
+
+setup_server_files() {
+    echo "Creating server configuration and permission files..." | tee -a "${LOG_FILE}"
+    touch "${ECHO_DIR}/services/server.conf"
+    touch "${ECHO_DIR}/perm/server.perm"
+    chmod 600 "${ECHO_DIR}/perm/server.perm"
+}
+
+setup_network_server() {
+    echo "Simulating network server setup..." | tee -a "${LOG_FILE}"
+}
+
+create_echo_query() {
+    cat > "${SQL_FILE}" <<'SQL'
+-- Teradata echo table used to store installation details
+CREATE TABLE IF NOT EXISTS echo_installation (
+    id INTEGER GENERATED ALWAYS AS IDENTITY,
+    step VARCHAR(255),
+    status VARCHAR(32),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Example query to list installation steps
+SELECT * FROM echo_installation ORDER BY created_at;
+SQL
+    echo "Created echo query at ${SQL_FILE}" | tee -a "${LOG_FILE}"
+}
+
+prepare_dw_finance() {
+    echo "Preparing data warehouse stubs for finance service..." | tee -a "${LOG_FILE}"
+    touch "${ECHO_DIR}/services/dw_finance_placeholder.txt"
+}
+
+install_teradata
+setup_server_files
+setup_network_server
+create_echo_query
+prepare_dw_finance
+
+echo "Teradata workflow completed." | tee -a "${LOG_FILE}"


### PR DESCRIPTION
## Summary
- add teradata_workflow.sh to simulate Teradata setup, server/network configuration, and finance DW stubs with echo logging
- define echo_installation table and example query in teradata_echo.sql

## Testing
- `bash scripts/teradata_workflow.sh`
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5949c088833288d16d8a8fbf1d45