### PR TITLE
Add setup guides and update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,3 +52,7 @@ updates:
     directory: "/"
     schedule: { interval: "weekly", day: "monday", time: "05:30", timezone: "Asia/Seoul" }
     groups: { npm-all: { applies-to: version-updates, patterns: ["*"] } }
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule: { interval: "weekly", day: "monday", time: "05:40", timezone: "Asia/Seoul" }

--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ Add the `--delete` flag to remove the files instead of just listing them:
 python scripts/remove_provenance_files.py --root . --delete
 ```
 
+
+### Setup Guides
+
+- [Docker](docker/README.md)
+- [Java](java/README.md)
+- [Maven](maven/README.md)
+- [Spring Boot](springboot/README.md)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,20 @@
+# Docker Setup
+
+## Installation
+
+```bash
+# Update package index
+sudo apt-get update
+# Install docker
+sudo apt-get install -y docker.io
+```
+
+## Upgrade
+
+To upgrade Docker, run:
+
+```bash
+sudo apt-get update && sudo apt-get install --only-upgrade docker.io
+```
+
+Dependabot monitors this directory to keep Docker images up to date.

--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,16 @@
+# Java Setup
+
+## Installation
+
+```bash
+sudo apt-get update
+sudo apt-get install -y openjdk-17-jdk
+```
+
+## Upgrade
+
+```bash
+sudo apt-get update && sudo apt-get install --only-upgrade openjdk-17-jdk
+```
+
+Dependabot will track Maven or Gradle builds that use this JDK.

--- a/maven/README.md
+++ b/maven/README.md
@@ -1,0 +1,16 @@
+# Maven Setup
+
+## Installation
+
+```bash
+sudo apt-get update
+sudo apt-get install -y maven
+```
+
+## Upgrade
+
+```bash
+sudo apt-get update && sudo apt-get install --only-upgrade maven
+```
+
+Projects using `pom.xml` will be automatically checked by Dependabot.

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -1,0 +1,17 @@
+# Spring Boot Setup
+
+## Creating a Project
+
+Use the Spring Initializr to generate a project:
+
+```bash
+curl https://start.spring.io/starter.tgz -d dependencies=web,actuator | tar -xzvf -
+```
+
+## Running
+
+```bash
+./mvnw spring-boot:run
+```
+
+Dependabot will update dependencies listed in `pom.xml` or `build.gradle`.


### PR DESCRIPTION
## Summary
- add installation guides for Docker, Java, Maven and Spring Boot
- link setup docs from main README
- configure Dependabot to watch new Docker directory

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `mvn -v`


------
https://chatgpt.com/codex/tasks/task_e_68b6fb65c05c833284eff4d42b4df242