### PR TITLE
Add Hitachi storage installation workflow

### DIFF
--- a/.github/workflows/hitachi-storage.yml
+++ b/.github/workflows/hitachi-storage.yml
@@ -1,0 +1,23 @@
+name: Hitachi Bulk Storage Install
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+      - 'feature/**'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  install-hitachi-storage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Hitachi Storage
+        env:
+          HITACHI_STORAGE_SIZE: large
+          HITACHI_STORAGE_RELEASE: ${{ github.ref_name }}
+        run: |
+          bash scripts/install_hitachi_storage.sh

--- a/scripts/install_hitachi_storage.sh
+++ b/scripts/install_hitachi_storage.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Parameters allow customization but default to large-scale installation
+SIZE=${HITACHI_STORAGE_SIZE:-large}
+RELEASE=${HITACHI_STORAGE_RELEASE:-latest}
+
+echo "[Hitachi Storage] Starting ${SIZE} installation for release ${RELEASE}."
+
+# Update package index and install hypothetical Hitachi CLI
+sudo apt-get update -y
+sudo apt-get install -y hitachi-storage-cli
+
+# Execute bulk installation using the CLI
+hitachi-storage-cli install --mode bulk --size "$SIZE" --release "$RELEASE"
+
+echo "[Hitachi Storage] Installation complete."


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install Hitachi storage on pushes and releases
- include script automating bulk Hitachi storage installation

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b5145348332bdabdcd97ac68f7a