### PR TITLE
Add Maven server workflow

### DIFF
--- a/.github/workflows/maven-cicd.yml
+++ b/.github/workflows/maven-cicd.yml
@@ -1,0 +1,39 @@
+---
+name: Maven Server Workflow
+
+'on':
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Verify Maven
+        run: mvn -v
+      - name: Server install
+        run: echo "Simulating server installation"
+      - name: Server upgrade
+        run: echo "Simulating server upgrade"
+      - name: Release build
+        run: mvn -B package --file pom.xml || echo "No Maven project found"
+      - name: Generate permission files
+        run: |
+          mkdir -p permissions
+          echo "permissions" > permissions/permissions.txt
+      - name: Generate c-c files
+        run: |
+          mkdir -p cc_files
+          for i in $(seq 1 100); do
+            touch cc_files/file_$i.c
+            touch cc_files/file_$i.cc
+          done
+          echo "Generated 100 c/c files"


### PR DESCRIPTION
## Summary
- add Maven Server Workflow with scheduled c/c file generation, permission file creation, and simulated server tasks

## Testing
- `yamllint .github/workflows/maven-cicd.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b98a34792c83328b7ead7d38e2e885